### PR TITLE
fix(ui): persist player bar and panels across navigation

### DIFF
--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -10,6 +10,7 @@ struct MainWindow: View {
     @State private var path = NavigationPath()
     @State private var showLogin = false
     @State private var searchText = ""
+    @State private var detailWidth: CGFloat = 0
 
     var body: some View {
         NavigationSplitView {
@@ -17,10 +18,32 @@ struct MainWindow: View {
                 .navigationSplitViewColumnWidth(min: 200, ideal: Theme.Layout.sidebarWidth, max: 280)
         } detail: {
             detailStack
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    detailWidth = width
+                }
+        }
+        .toolbar {
+            if #available(macOS 26.0, *) {
+                ToolbarItem(placement: .primaryAction) {
+                    SearchFieldView { query in
+                        path.append(Destination.search(query))
+                    }
+                }
+                .sharedBackgroundVisibility(.hidden)
+            } else {
+                ToolbarItem(placement: .primaryAction) {
+                    SearchFieldView { query in
+                        path.append(Destination.search(query))
+                    }
+                }
+            }
         }
         // Immersive now-playing page: hide the whole window toolbar
         // (sidebar toggle, navigation title, search field).
         .toolbar(player.showNowPlaying ? .hidden : .automatic, for: .windowToolbar)
+        .playerChrome(detailWidth: detailWidth)
         .environment(\.openLogin, { showLogin = true })
         .task {
             DesktopLyricsController.shared.sync(with: settings.showDesktopLyrics)
@@ -52,30 +75,8 @@ struct MainWindow: View {
     private var detailStack: some View {
         NavigationStack(path: $path) {
             rootView
+                .playerContentInset()
                 .appDestinations()
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-        }
-        .overlay(alignment: .trailing) {
-            rightPanel
-        }
-        .animation(AppAnimation.standard, value: player.activePanel)
-        .toolbar {
-            if #available(macOS 26.0, *) {
-                ToolbarItem(placement: .primaryAction) {
-                    SearchFieldView { query in
-                        path.append(Destination.search(query))
-                    }
-                }
-                .sharedBackgroundVisibility(.hidden)
-            } else {
-                ToolbarItem(placement: .primaryAction) {
-                    SearchFieldView { query in
-                        path.append(Destination.search(query))
-                    }
-                }
-            }
         }
         .onChange(of: selection) {
             path = NavigationPath()
@@ -126,23 +127,6 @@ struct MainWindow: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ViewBuilder
-    private var rightPanel: some View {
-        if let panel = player.activePanel {
-            Group {
-                switch panel {
-                case .lyrics:
-                    LyricsPanel()
-                case .queue:
-                    QueuePanel()
-                }
-            }
-            .padding(.top, 12)
-            .padding(.bottom, Theme.Layout.playerBarHeight + 20)
-            .padding(.trailing, 16)
-            .transition(.move(edge: .trailing).combined(with: .opacity))
-        }
-    }
 }
 
 // MARK: - Search field

--- a/Sources/Kumone/Features/Navigation.swift
+++ b/Sources/Kumone/Features/Navigation.swift
@@ -4,6 +4,41 @@ extension EnvironmentValues {
     @Entry var openLogin: () -> Void = {}
 }
 
+struct PlayerChromeModifier: ViewModifier {
+    @Environment(PlayerService.self) private var player
+    let detailWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottomTrailing) {
+                PlayerBar()
+                    .frame(width: detailWidth)
+            }
+            .overlay(alignment: .trailing) {
+                rightPanel
+            }
+            .animation(AppAnimation.standard, value: player.activePanel)
+    }
+
+    @ViewBuilder
+    private var rightPanel: some View {
+        if let panel = player.activePanel {
+            Group {
+                switch panel {
+                case .lyrics:
+                    LyricsPanel()
+                case .queue:
+                    QueuePanel()
+                }
+            }
+            .padding(.top, 12)
+            .padding(.bottom, Theme.Layout.playerBarHeight + 20)
+            .padding(.trailing, 16)
+            .transition(.move(edge: .trailing).combined(with: .opacity))
+        }
+    }
+}
+
 enum SidebarItem: Hashable {
     case home
     case explore
@@ -29,25 +64,36 @@ enum Destination: Hashable {
 struct DestinationsModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.navigationDestination(for: Destination.self) { destination in
-            switch destination {
-            case .playlist(let id):
-                PlaylistDetailView(playlistID: id)
-            case .album(let id):
-                AlbumDetailView(albumID: id)
-            case .artist(let id):
-                ArtistDetailView(artistID: id)
-            case .daily:
-                DailySongsView()
-            case .toplists:
-                ToplistsView()
-            case .search(let query):
-                SearchView(query: query)
+            Group {
+                switch destination {
+                case .playlist(let id):
+                    PlaylistDetailView(playlistID: id)
+                case .album(let id):
+                    AlbumDetailView(albumID: id)
+                case .artist(let id):
+                    ArtistDetailView(artistID: id)
+                case .daily:
+                    DailySongsView()
+                case .toplists:
+                    ToplistsView()
+                case .search(let query):
+                    SearchView(query: query)
+                }
             }
+            .playerContentInset()
         }
     }
 }
 
 extension View {
+    func playerChrome(detailWidth: CGFloat) -> some View {
+        modifier(PlayerChromeModifier(detailWidth: detailWidth))
+    }
+
+    func playerContentInset() -> some View {
+        safeAreaPadding(.bottom, Theme.Layout.playerBarHeight + 10)
+    }
+
     func appDestinations() -> some View {
         modifier(DestinationsModifier())
     }


### PR DESCRIPTION
## 说明

修复从推荐、精选等页面进入歌单、专辑或歌手详情后，播放栏、右侧面板和搜索栏消失的问题。

同时避免导航时重新创建播放栏及歌词/播放队列面板，防止封面和歌名重复刷新。

## 改动

- 将播放栏和右侧面板提升为窗口级单实例
- 根据详情栏实际宽度调整播放栏，避免覆盖侧边栏
- 为所有导航页面统一保留底部内容空间
- 将搜索栏移动到分栏容器层级，使其在导航后保持显示

## 验证

- 从推荐页进入歌单，播放栏和搜索栏正常显示
- 从歌单继续进入专辑、歌手页面，播放栏保持显示
- 打开歌词或播放队列后继续导航，面板内容保持稳定，不重新加载
- 直接从侧边栏打开歌单的原有行为不受影响
