### PR TITLE
fix(macOS): preserve window width after closing now playing

### DIFF
--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -25,6 +25,7 @@ struct MainWindow: View {
                     detailWidth = width
                 }
         }
+        .navigationSplitViewStyle(.balanced)
         .toolbar {
             if #available(macOS 26.0, iOS 26.0, *) {
                 ToolbarItem(placement: .primaryAction) {


### PR DESCRIPTION
## Summary

- use the balanced navigation split view style when toggling the sidebar for the immersive now-playing view
- prevent Home and Explore content from becoming wider after closing now playing

## Testing

- `Scripts/compile_and_run.sh debug`
- manually opened now playing from Home and closed it with the top-left button; the window and content width remained unchanged