### PR TITLE
fix(macOS): 退出沉浸式播放页后窗口不再变宽（#19 未真正修复）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 section the English bullets come first, followed by their Simplified Chinese
 counterparts. 段落格式：`## <版本号> - <日期>`，条目必须写成单行。
 
+## 0.3.4 - 2026-08-25
+
+### Fixed / 修复
+
+- Window no longer grows by the sidebar's width every time the immersive now-playing page is dismissed. The window minimum was expressed as a SwiftUI content constraint (`.frame(minWidth:)` + `.windowResizability(.contentMinSize)`), so while the now-playing page collapsed the sidebar the whole 1020pt minimum landed on the detail column; restoring the sidebar then added its width on top and the window was forced to 1248pt. The minimum is now reduced by the sidebar's width while it is collapsed, so the restored total lands back on 1020pt. Measured: 1020→1020, 1100→1100 (previously 1248 / 1328).
+- 退出沉浸式播放页时窗口不再每次都变宽一个侧边栏的宽度。窗口最小宽度原本是通过 SwiftUI 的内容约束（`.frame(minWidth:)` + `.windowResizability(.contentMinSize)`）表达的，而播放页会折叠侧边栏，这时 1020pt 的下限全部落到了详情列上；恢复侧边栏后再加上它的宽度，窗口就被强行撑到 1248pt。现在侧边栏折叠期间会把该下限减去侧边栏宽度，恢复后总和正好回到 1020pt。实测：1020→1020、1100→1100（此前为 1248 / 1328）。
+
 ## 0.3.3 - 2026-08-25
 
 ### Improved / 改进

--- a/Sources/Kumone/DesignSystem/Theme.swift
+++ b/Sources/Kumone/DesignSystem/Theme.swift
@@ -30,6 +30,18 @@ enum Theme {
         /// Bottom inset pages need so scrolled content clears the floating bar.
         static var playerChromeClearance: CGFloat { playerBarHeight + playerBarBottomMargin }
         static let minWindowWidth: CGFloat = 1020
+        /// Width the split view's divider occupies between the two columns.
+        static let splitDividerWidth: CGFloat = 8
+        /// Window minimum while the sidebar is collapsed. The window-wide
+        /// minimum is a *content* constraint, so with the sidebar hidden it
+        /// lands entirely on the detail column; restoring the sidebar would
+        /// then add its width on top and `.contentMinSize` would widen the
+        /// window every time the now-playing page is dismissed (#19).
+        /// Subtracting the sidebar here keeps the restored total at
+        /// `minWindowWidth`.
+        static var minWindowWidthSidebarCollapsed: CGFloat {
+            minWindowWidth - sidebarWidth - splitDividerWidth
+        }
         static let minWindowHeight: CGFloat = 640
         static let defaultWindowWidth: CGFloat = 1200
         static let defaultWindowHeight: CGFloat = 780

--- a/Sources/Kumone/KumoneApp.swift
+++ b/Sources/Kumone/KumoneApp.swift
@@ -20,7 +20,9 @@ public struct KumoneApp: App {
                 .environmentObject(toasts)
                 .tint(Theme.accent)
                 .preferredColorScheme(settings.appearance.colorScheme)
-                .frame(minWidth: Theme.Layout.minWindowWidth,
+                .frame(minWidth: player.showNowPlaying
+                           ? Theme.Layout.minWindowWidthSidebarCollapsed
+                           : Theme.Layout.minWindowWidth,
                        minHeight: Theme.Layout.minWindowHeight)
         }
         .defaultSize(width: Theme.Layout.defaultWindowWidth,


### PR DESCRIPTION
## 问题

进入沉浸式播放页再收起，窗口宽度每次都会增加 228pt（侧边栏 220 + 分隔线 8）。

#19 试图修这个问题（加了 `.navigationSplitViewStyle(.balanced)`），但**没有生效** —— 该 modifier 只改变两列之间的宽度分配策略，碰不到真正决定窗口最小宽度的那个约束。在合并了 #19 的 `022eb85` 上仍能稳定复现。

## 根因

窗口最小宽度是用 SwiftUI 的**内容**约束表达的：

```swift
.frame(minWidth: Theme.Layout.minWindowWidth)   // 1020
.windowResizability(.contentMinSize)
```

而打开播放页时 `MainWindow.swift` 会把侧边栏折叠为 `.detailOnly`（这是为了修 #6 的分隔线光标泄漏）。侧边栏一旦隐藏，这 1020pt 的下限就整个落到了详情列上；收起播放页、侧边栏恢复后，内容最小宽度变成 `1020 + 220 + 8 = 1248`，`.contentMinSize` 于是把窗口强行撑到 1248pt。

窗口越窄越容易触发：宽度 ≥ 1248 时看不出问题，而默认最小宽度 1020 的窗口每次必现。

## 修复

侧边栏折叠期间，把该下限减去侧边栏与分隔线的宽度，这样恢复后总和正好回到 `minWindowWidth`。

## 验证

脚本化驱动「打开 → 收起」，在三个起始宽度下测量 `NSWindow.frame.width`：

| 起始宽度 | 修复前收起后 | 修复后 |
|---|---|---|
| 1020 | 1248 (+228) | **1020** |
| 1100 | 1328 (+228) | **1100** |
| 1400 | 1400 | **1400** |

同时确认最小尺寸约束依然有效：强行把 frame 设成 600pt 会被钳回 1020pt（`contentMinSize=(1020, 692)`）。

## 试过但不可行的方案

把最小尺寸设到 AppKit 的 `NSWindow.minSize` / `contentMinSize` 上（语义上更正统，与列布局解耦）。**行不通**：SwiftUI 的 `WindowGroup` 会持续按内容重算并覆盖这两个属性 —— 实测被改回 `(228, 163)`，窗口可以被缩到 600pt。因此最终方案留在 SwiftUI 侧。

## 已知副作用

沉浸式播放页打开期间，窗口最小宽度临时为 792pt。若在该页面手动把窗口拖到 1020pt 以下，退出时会被弹回 1020pt。正常使用不会触发。

## 备注

#19 引入的 `.navigationSplitViewStyle(.balanced)` **保留未动** —— 它对本问题无效，但会影响两列宽度分配的观感，是否保留是独立的取舍，留给维护者决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
