### PR TITLE
feat(macOS): Dock 右键菜单；修复沉浸式播放页顶部多出的工具栏空白

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 section the English bullets come first, followed by their Simplified Chinese
 counterparts. 段落格式：`## <版本号> - <日期>`，条目必须写成单行。
 
+## 0.3.4 - 2026-08-26
+
+### Added / 新增
+
+- Dock menu (right-click the Dock icon): play/pause, next, previous, shuffle, a repeat submenu, and the last six places playback started from — playlists, albums, artists, daily recommendations, cloud disk, the play-record list, heartbeat mode and personal FM. Picking one reloads it and plays; heartbeat mode and personal FM are regenerated rather than resumed, since neither is a fixed list.
+- Dock 菜单（右键 Dock 图标）：播放/暂停、下一首、上一首、随机播放、循环模式子菜单，以及最近播放过的 6 个来源——歌单、专辑、歌手、每日推荐、音乐云盘、最近播放、心动模式、私人漫游。点击即重新载入并播放；心动模式与私人漫游会重新生成而非恢复原队列，因为它们本就不是固定歌单。
+
+### Fixed / 修复
+
+- Immersive now-playing page no longer leaves a toolbar's worth of empty space at the top: the window toolbar is hidden there, but SwiftUI kept reserving its safe area, pushing the close button ~68pt down from the window edge. The button's insets are also even now (20pt on both edges, previously 16pt top / 20pt leading). iOS keeps its safe area, where the inset is the status bar / notch.
+- 沉浸式播放页顶部不再多出一个工具栏高度的空白：该页面隐藏了窗口工具栏，但 SwiftUI 仍为其保留安全区域，把收起按钮推到了距窗口顶部约 68pt 的位置。按钮四边间距也统一为 20pt（此前为上 16pt / 左 20pt）。iOS 保持原有安全区域行为——那里的内边距是状态栏 / 灵动岛。
+
 ## 0.3.3 - 2026-08-25
 
 ### Improved / 改进

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -30,6 +30,55 @@ enum PlaySource: Equatable {
     }
 }
 
+/// Where playback started from — listed under "Recently Played" in the Dock
+/// menu, where picking one reloads it and starts playing again.
+///
+/// This is deliberately separate from `PlaySource`: heartbeat mode plays out
+/// of the liked-songs playlist for scrobbling purposes, but as a *place* it is
+/// its own thing, and the recents page has no source at all.
+struct PlayContext: Codable, Hashable {
+    enum Kind: String, Codable {
+        /// Reloaded by id.
+        case playlist, album, artist
+        /// Fixed per-account entry points, each reloaded from its own API.
+        case daily, cloud, recents, heartbeat, fm
+    }
+
+    let kind: Kind
+    /// Zero for the fixed entry points, which have no id of their own.
+    let id: Int
+    let name: String
+
+    static func playlist(id: Int, name: String) -> PlayContext {
+        .init(kind: .playlist, id: id, name: name)
+    }
+
+    static func album(id: Int, name: String) -> PlayContext {
+        .init(kind: .album, id: id, name: name)
+    }
+
+    static func artist(id: Int, name: String) -> PlayContext {
+        .init(kind: .artist, id: id, name: name)
+    }
+
+    static var daily: PlayContext { .init(kind: .daily, id: 0, name: String(localized: "每日推荐")) }
+    static var cloud: PlayContext { .init(kind: .cloud, id: 0, name: String(localized: "音乐云盘")) }
+    static var recents: PlayContext { .init(kind: .recents, id: 0, name: String(localized: "最近播放")) }
+    static var heartbeat: PlayContext { .init(kind: .heartbeat, id: 0, name: String(localized: "心动模式")) }
+    static var fm: PlayContext { .init(kind: .fm, id: 0, name: String(localized: "私人漫游")) }
+
+    /// Identity is the place, not its current title — a renamed playlist is
+    /// still the same entry in the recents list.
+    static func == (lhs: PlayContext, rhs: PlayContext) -> Bool {
+        lhs.kind == rhs.kind && lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(id)
+    }
+}
+
 enum RightPanel {
     case lyrics, queue
 }
@@ -82,6 +131,9 @@ final class PlayerService: ObservableObject {
 
     @Published private(set) var isFMMode = false
     @Published private(set) var fmUpcoming: [Track] = []
+    /// Where playback was most recently started from, newest first —
+    /// surfaced as "Recently Played" in the Dock menu.
+    @Published private(set) var recentContexts: [PlayContext] = []
     @Published private(set) var lyrics: ParsedLyrics?
     @Published var activePanel: RightPanel?
     @Published var showNowPlaying = false
@@ -203,8 +255,13 @@ final class PlayerService: ObservableObject {
 
     // MARK: - Entry points
 
-    func play(tracks: [Track], source: PlaySource, startAt track: Track? = nil) {
+    /// - Parameter context: the place these tracks came from. Supplying it
+    ///   lists that place in the Dock menu's recently played section; callers
+    ///   playing an ad-hoc selection (search results, a single track) omit it.
+    func play(tracks: [Track], source: PlaySource, startAt track: Track? = nil,
+              context: PlayContext? = nil) {
         guard !tracks.isEmpty else { return }
+        if let context { recordRecent(context) }
         isFMMode = false
         queue = tracks
         self.source = source
@@ -336,6 +393,7 @@ final class PlayerService: ObservableObject {
 
     func startFM() {
         guard !isFMMode || !isPlaying else { return }
+        recordRecent(.fm)
         isFMMode = true
         shuffleEnabled = false
         repeatMode = .off
@@ -548,11 +606,73 @@ final class PlayerService: ObservableObject {
 
     // MARK: - Persistence
 
+    private static let recentContextsLimit = 6
+
+    private func recordRecent(_ context: PlayContext) {
+        recentContexts.removeAll { $0 == context }
+        recentContexts.insert(context, at: 0)
+        if recentContexts.count > Self.recentContextsLimit {
+            recentContexts.removeLast(recentContexts.count - Self.recentContextsLimit)
+        }
+    }
+
+    /// Reloads a place from the recents list and starts playing it again.
+    func play(context: PlayContext) {
+        // Personal FM is a stream, not a fixed list — restart it in place.
+        guard context.kind != .fm else { return startFM() }
+        Task {
+            do {
+                guard let resolved = try await resolve(context) else { return }
+                play(tracks: resolved.tracks, source: resolved.source, context: context)
+            } catch {
+                ToastCenter.shared.show(error.localizedDescription)
+            }
+        }
+    }
+
+    private func resolve(_ context: PlayContext) async throws -> (tracks: [Track], source: PlaySource)? {
+        switch context.kind {
+        case .fm:
+            return nil
+        case .album:
+            return (try await NeteaseAPI.album(id: context.id).songs, .album(context.id))
+        case .artist:
+            return (try await NeteaseAPI.artist(id: context.id).hotSongs, .artist(context.id))
+        case .daily:
+            return (try await NeteaseAPI.dailyRecommendSongs(), .daily)
+        case .cloud:
+            let songs = try await NeteaseAPI.cloudSongs().data?.compactMap(\.simpleSong) ?? []
+            return (songs, .cloud)
+        case .recents:
+            guard let uid = AccountStore.shared.profile?.userId else { return nil }
+            return (try await NeteaseAPI.playRecords(uid: uid, week: false).map(\.song), .none)
+        case .heartbeat:
+            // Regenerated from a fresh seed, the same way the Home card does it.
+            guard let liked = AccountStore.shared.likedSongsPlaylist,
+                  let seed = AccountStore.shared.likedTrackIDs.randomElement() else { return nil }
+            let tracks = try await NeteaseAPI.intelligenceList(songID: seed, playlistID: liked.id)
+            return (tracks, .playlist(liked.id))
+        case .playlist:
+            let response = try await NeteaseAPI.playlistDetail(id: context.id)
+            var tracks = response.playlist.tracks
+            // /v6/playlist/detail only carries the first page of tracks.
+            let remaining = response.playlist.trackIds.map(\.id).dropFirst(tracks.count)
+            for chunk in stride(from: 0, to: remaining.count, by: 500)
+                .map({ Array(remaining.dropFirst($0).prefix(500)) }) {
+                guard let more = try? await NeteaseAPI.songDetails(ids: chunk) else { break }
+                tracks += more.songs
+            }
+            return (tracks, .playlist(context.id))
+        }
+    }
+
     private struct PersistedState: Codable {
         var queue: [Track]
         var currentID: Int?
         var repeatMode: String
         var shuffle: Bool
+        /// Optional so state files written before recents existed still decode.
+        var recentContexts: [PlayContext]?
     }
 
     private func persistState() {
@@ -560,7 +680,8 @@ final class PlayerService: ObservableObject {
             queue: Array(queue.prefix(1000)),
             currentID: currentTrack?.id,
             repeatMode: repeatMode.rawValue,
-            shuffle: shuffleEnabled
+            shuffle: shuffleEnabled,
+            recentContexts: recentContexts
         )
         guard let data = try? JSONEncoder().encode(state) else { return }
         let url = Self.stateFileURL
@@ -571,8 +692,13 @@ final class PlayerService: ObservableObject {
 
     private func restoreState() {
         guard let data = try? Data(contentsOf: Self.stateFileURL),
-              let state = try? JSONDecoder().decode(PersistedState.self, from: data),
-              !state.queue.isEmpty else { return }
+              let state = try? JSONDecoder().decode(PersistedState.self, from: data)
+        else { return }
+        // Recents outlive the queue: restore them before bailing out on an
+        // empty queue, or the next played track persists an empty list over
+        // them and the Dock menu loses its history for good.
+        recentContexts = Array((state.recentContexts ?? []).prefix(Self.recentContextsLimit))
+        guard !state.queue.isEmpty else { return }
         queue = state.queue
         shuffleEnabled = state.shuffle
         if shuffleEnabled {

--- a/Sources/Kumone/Features/Detail/AlbumDetailView.swift
+++ b/Sources/Kumone/Features/Detail/AlbumDetailView.swift
@@ -39,7 +39,8 @@ struct AlbumDetailView: View {
 
                     TrackListView(
                         tracks: tracks,
-                        source: .album(albumID)
+                        source: .album(albumID),
+                        context: .album(id: albumID, name: album.name)
                     )
                     .padding(.horizontal, isCompact ? 6 : Theme.Layout.contentInset - 10)
 
@@ -177,7 +178,8 @@ struct AlbumDetailView: View {
             // Compact Action Bar
             HStack(spacing: 10) {
                 Button {
-                    player.play(tracks: tracks, source: .album(albumID))
+                    player.play(tracks: tracks, source: .album(albumID),
+                                context: .album(id: albumID, name: album.name))
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "play.fill")
@@ -265,7 +267,8 @@ struct AlbumDetailView: View {
 
                 HStack(spacing: 10) {
                     Button {
-                        player.play(tracks: tracks, source: .album(albumID))
+                        player.play(tracks: tracks, source: .album(albumID),
+                                context: .album(id: albumID, name: album.name))
                     } label: {
                         Label("播放", systemImage: "play.fill")
                             .font(.system(size: 13, weight: .semibold))

--- a/Sources/Kumone/Features/Detail/ArtistDetailView.swift
+++ b/Sources/Kumone/Features/Detail/ArtistDetailView.swift
@@ -45,7 +45,8 @@ struct ArtistDetailView: View {
                         TrackListView(
                             tracks: hotSongs,
                             style: .compact,
-                            source: .artist(artistID)
+                            source: .artist(artistID),
+                            context: .artist(id: artistID, name: artist.name)
                         )
                         .padding(.horizontal, isCompact ? 6 : Theme.Layout.contentInset - 10)
                     }
@@ -179,7 +180,8 @@ struct ArtistDetailView: View {
             // Compact Action Bar
             HStack(spacing: 10) {
                 Button {
-                    player.play(tracks: hotSongs, source: .artist(artistID))
+                    player.play(tracks: hotSongs, source: .artist(artistID),
+                                context: .artist(id: artistID, name: artist.name))
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "play.fill")
@@ -239,7 +241,8 @@ struct ArtistDetailView: View {
 
                 HStack(spacing: 10) {
                     Button {
-                        player.play(tracks: hotSongs, source: .artist(artistID))
+                        player.play(tracks: hotSongs, source: .artist(artistID),
+                                context: .artist(id: artistID, name: artist.name))
                     } label: {
                         Label("播放热门", systemImage: "play.fill")
                             .font(.system(size: 13, weight: .semibold))

--- a/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
+++ b/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
@@ -111,6 +111,7 @@ struct PlaylistDetailView: View {
                         tracks: model.filteredTracks,
                         privileges: model.privileges,
                         source: .playlist(playlistID),
+                        context: model.detail.map { .playlist(id: playlistID, name: $0.name) },
                         removableFromPlaylistID: isOwnPlaylist ? playlistID : nil,
                         onRemoved: { model.remove($0) }
                     )
@@ -216,7 +217,8 @@ struct PlaylistDetailView: View {
             // Compact Action Bar
             HStack(spacing: 10) {
                 Button {
-                    player.play(tracks: playable, source: .playlist(playlistID))
+                    player.play(tracks: playable, source: .playlist(playlistID),
+                                context: model.detail.map { .playlist(id: playlistID, name: $0.name) })
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "play.fill")
@@ -325,7 +327,8 @@ struct PlaylistDetailView: View {
     private func actionRow(_ detail: PlaylistDetail) -> some View {
         HStack(spacing: 10) {
             Button {
-                player.play(tracks: playable, source: .playlist(playlistID))
+                player.play(tracks: playable, source: .playlist(playlistID),
+                            context: .playlist(id: playlistID, name: detail.name))
             } label: {
                 Label("播放全部", systemImage: "play.fill")
                     .font(.system(size: 13, weight: .semibold))
@@ -397,7 +400,7 @@ struct PlaylistDetailView: View {
                     ToastCenter.shared.show(String(localized: "心动模式暂时不可用"))
                     return
                 }
-                player.play(tracks: tracks, source: .playlist(playlistID))
+                player.play(tracks: tracks, source: .playlist(playlistID), context: .heartbeat)
                 ToastCenter.shared.show(String(localized: "已开启心动模式"))
             } catch {
                 ToastCenter.shared.show(error.localizedDescription)

--- a/Sources/Kumone/Features/DockMenu.swift
+++ b/Sources/Kumone/Features/DockMenu.swift
@@ -1,0 +1,107 @@
+#if os(macOS)
+import AppKit
+
+/// Dock icon menu (right-click / long-press on the Dock tile).
+///
+/// AppKit asks for this menu each time it is opened, so it is rebuilt from
+/// the player's current state rather than kept in sync. Layout follows what
+/// Spotify and Music put there: transport controls, shuffle / repeat state,
+/// and recently played tracks.
+@MainActor
+final class DockMenu: NSObject, NSMenuDelegate {
+    static let shared = DockMenu()
+
+    private let player = PlayerService.shared
+
+    func makeMenu() -> NSMenu {
+        let menu = NSMenu()
+        // The Dock menu is not in the responder chain, so nothing would
+        // validate the items for us.
+        menu.autoenablesItems = false
+
+        add(to: menu,
+            title: player.isPlaying ? String(localized: "暂停") : String(localized: "播放"),
+            action: #selector(togglePlayPause),
+            enabled: player.hasCurrentTrack)
+        menu.addItem(.separator())
+
+        add(to: menu, title: String(localized: "下一首"),
+            action: #selector(next), enabled: player.hasCurrentTrack)
+        add(to: menu, title: String(localized: "上一首"),
+            action: #selector(previous), enabled: player.hasCurrentTrack)
+        menu.addItem(.separator())
+
+        let shuffle = add(to: menu, title: String(localized: "随机播放"),
+                          action: #selector(toggleShuffle), enabled: true)
+        shuffle.state = player.shuffleEnabled ? .on : .off
+
+        // Three-way repeat reads better as a submenu than as one checkmark.
+        let repeatItem = NSMenuItem(title: String(localized: "循环模式"),
+                                    action: nil, keyEquivalent: "")
+        let repeatMenu = NSMenu()
+        repeatMenu.autoenablesItems = false
+        for mode in RepeatMode.allCases {
+            let item = add(to: repeatMenu, title: mode.menuTitle,
+                           action: #selector(setRepeatMode(_:)), enabled: true)
+            item.representedObject = mode.rawValue
+            item.state = player.repeatMode == mode ? .on : .off
+        }
+        repeatItem.submenu = repeatMenu
+        menu.addItem(repeatItem)
+
+        if !player.recentContexts.isEmpty {
+            menu.addItem(.separator())
+            let header = NSMenuItem(title: String(localized: "最近播放"),
+                                    action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            menu.addItem(header)
+
+            for context in player.recentContexts {
+                let item = add(to: menu, title: context.name,
+                               action: #selector(playRecent(_:)), enabled: true)
+                item.representedObject = context
+                item.indentationLevel = 1
+            }
+        }
+
+        return menu
+    }
+
+    @discardableResult
+    private func add(to menu: NSMenu, title: String, action: Selector, enabled: Bool) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.isEnabled = enabled
+        menu.addItem(item)
+        return item
+    }
+
+    // MARK: - Actions
+
+    @objc private func togglePlayPause() { player.togglePlayPause() }
+    @objc private func next() { player.next() }
+    @objc private func previous() { player.previous() }
+    @objc private func toggleShuffle() { player.toggleShuffle() }
+
+    @objc private func setRepeatMode(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String,
+              let mode = RepeatMode(rawValue: raw) else { return }
+        player.repeatMode = mode
+    }
+
+    @objc private func playRecent(_ sender: NSMenuItem) {
+        guard let context = sender.representedObject as? PlayContext else { return }
+        player.play(context: context)
+    }
+}
+
+private extension RepeatMode {
+    var menuTitle: String {
+        switch self {
+        case .off: return String(localized: "不循环")
+        case .all: return String(localized: "列表循环")
+        case .one: return String(localized: "单曲循环")
+        }
+    }
+}
+#endif

--- a/Sources/Kumone/Features/Explore/ExploreView.swift
+++ b/Sources/Kumone/Features/Explore/ExploreView.swift
@@ -157,7 +157,8 @@ struct ExploreView: View {
                 let ids = detail.playlist.trackIds.map(\.id)
                 tracks = (try? await NeteaseAPI.songDetails(ids: Array(ids.prefix(500))))?.songs ?? []
             }
-            player.play(tracks: tracks, source: .playlist(id))
+            player.play(tracks: tracks, source: .playlist(id),
+                        context: .playlist(id: id, name: detail.playlist.name))
         }
     }
 }

--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -281,7 +281,8 @@ struct HomeView: View {
                     ToastCenter.shared.show(String(localized: "心动模式暂时不可用"))
                     return
                 }
-                player.play(tracks: tracks, source: .playlist(likedList.id))
+                player.play(tracks: tracks, source: .playlist(likedList.id),
+                            context: .heartbeat)
                 ToastCenter.shared.show(String(localized: "已开启心动模式"))
             } catch {
                 ToastCenter.shared.show(error.localizedDescription)
@@ -318,7 +319,8 @@ struct HomeView: View {
             ) {
                 Task {
                     if let detail = try? await NeteaseAPI.album(id: album.id) {
-                        player.play(tracks: detail.songs, source: .album(album.id))
+                        player.play(tracks: detail.songs, source: .album(album.id),
+                                    context: .album(id: album.id, name: album.name))
                     }
                 }
             }
@@ -376,7 +378,8 @@ struct HomeView: View {
                 let ids = detail.playlist.trackIds.map(\.id)
                 tracks = (try? await NeteaseAPI.songDetails(ids: Array(ids.prefix(500))))?.songs ?? []
             }
-            player.play(tracks: tracks, source: .playlist(id))
+            player.play(tracks: tracks, source: .playlist(id),
+                        context: .playlist(id: id, name: detail.playlist.name))
         }
     }
 }

--- a/Sources/Kumone/Features/Pages/DailySongsView.swift
+++ b/Sources/Kumone/Features/Pages/DailySongsView.swift
@@ -28,7 +28,7 @@ struct DailySongsView: View {
                                    subtitle: "多听几首歌培养口味，每天 6:00 更新")
                         .frame(minHeight: 300)
                 } else {
-                    TrackListView(tracks: tracks, source: .daily)
+                    TrackListView(tracks: tracks, source: .daily, context: .daily)
                         .padding(.horizontal, Theme.Layout.contentInset - 10)
                 }
                 PlayerClearanceSpacer()
@@ -72,7 +72,7 @@ struct DailySongsView: View {
                 Spacer()
 
                 Button {
-                    player.play(tracks: tracks, source: .daily)
+                    player.play(tracks: tracks, source: .daily, context: .daily)
                 } label: {
                     Label("播放全部", systemImage: "play.fill")
                         .font(.system(size: 13, weight: .semibold))

--- a/Sources/Kumone/Features/Pages/LibraryPages.swift
+++ b/Sources/Kumone/Features/Pages/LibraryPages.swift
@@ -25,7 +25,7 @@ struct RecentsView: View {
                     Spacer()
 
                     Button {
-                        player.play(tracks: records.map(\.song), source: .none)
+                        player.play(tracks: records.map(\.song), source: .none, context: .recents)
                     } label: {
                         Label("播放全部", systemImage: "play.fill")
                             .font(.system(size: 12.5, weight: .semibold))
@@ -68,7 +68,8 @@ struct RecentsView: View {
                     style: .compact,
                     trailingText: String(localized: "\(record.playCount) 次")
                 ) {
-                    player.play(tracks: records.map(\.song), source: .none, startAt: record.song)
+                    player.play(tracks: records.map(\.song), source: .none, startAt: record.song,
+                                   context: .recents)
                 }
             }
         }
@@ -105,7 +106,7 @@ struct CloudView: View {
                     }
                     Spacer()
                     Button {
-                        player.play(tracks: tracks, source: .cloud)
+                        player.play(tracks: tracks, source: .cloud, context: .cloud)
                     } label: {
                         Label("播放全部", systemImage: "play.fill")
                             .font(.system(size: 12.5, weight: .semibold))
@@ -128,7 +129,7 @@ struct CloudView: View {
                                    subtitle: "在网易云音乐客户端上传的歌曲会出现在这里")
                         .frame(minHeight: 300)
                 } else {
-                    TrackListView(tracks: tracks, style: .compact, source: .cloud)
+                    TrackListView(tracks: tracks, style: .compact, source: .cloud, context: .cloud)
                         .padding(.horizontal, Theme.Layout.contentInset - 10)
                 }
                 PlayerClearanceSpacer()

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -38,7 +38,7 @@ struct NowPlayingView: View {
                         .background(.white.opacity(0.12), in: Circle())
                 }
                 .buttonStyle(.pressable)
-                .padding(.top, 16)
+                .padding(.top, 20)
                 .padding(.leading, 20)
             }
             .overlay(alignment: .topTrailing) {
@@ -55,11 +55,18 @@ struct NowPlayingView: View {
                             .background(.white.opacity(0.12), in: Circle())
                     }
                     .buttonStyle(.pressable)
-                    .padding(.top, 16)
+                    .padding(.top, 20)
                     .padding(.trailing, 20)
                 }
             }
         }
+        #if os(macOS)
+        // The window toolbar is hidden while this page is up, but SwiftUI keeps
+        // reserving its safe area, which pushed the whole immersive layout —
+        // close button included — a toolbar's height down from the window top.
+        // iOS keeps its safe area: there the inset is the status bar / notch.
+        .ignoresSafeArea()
+        #endif
         .preferredColorScheme(.dark)
         .task(id: player.currentTrack?.id) {
             await loadArtwork()

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -246,6 +246,8 @@ struct TrackListView: View {
     var style: TrackRowStyle = .full
     var privileges: [Int: TrackPrivilege] = [:]
     var source: PlaySource = .none
+    /// The place this list belongs to, for the Dock menu's recents.
+    var context: PlayContext?
     var removableFromPlaylistID: Int?
     var onRemoved: ((Track) -> Void)?
 
@@ -263,7 +265,8 @@ struct TrackListView: View {
                     removableFromPlaylistID: removableFromPlaylistID,
                     onRemoved: { onRemoved?(track) }
                 ) {
-                    player.play(tracks: playableTracks, source: source, startAt: track)
+                    player.play(tracks: playableTracks, source: source, startAt: track,
+                                context: context)
                 }
             }
         }

--- a/Sources/Kumone/KumoneApp.swift
+++ b/Sources/Kumone/KumoneApp.swift
@@ -110,6 +110,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @MainActor
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        DockMenu.shared.makeMenu()
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }

--- a/Sources/Kumone/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kumone/Resources/en.lproj/Localizable.strings
@@ -279,3 +279,8 @@
 "检测到 TrollStore：可在应用内下载并自动安装新版本" = "TrollStore detected: new versions download and install in-app";
 "未检测到 TrollStore：检查更新会打开发布页，需用侧载工具重新安装（登录状态与设置保留）" = "No TrollStore: Check for Updates opens the release page; reinstall with your sideloading tool (sign-in and settings are kept)";
 "可能被网易云风控拦截而不可用，推荐使用扫码登录" = "May be blocked by NetEase risk control and unavailable — QR sign-in is recommended";
+
+/* Dock menu */
+"不循环" = "Off";
+"列表循环" = "Repeat All";
+"单曲循环" = "Repeat One";


### PR DESCRIPTION
两个独立的 macOS 原生行为改进，各一个 commit。

## 1. Dock 右键菜单

右键 Dock 图标现在提供播放/暂停、下一首、上一首、随机播放、循环模式子菜单，以及**最近播放的 6 个来源**——布局参照 Spotify 与 Music。

最近播放列的是**来源**而非单曲，点击即重新载入并播放。八种入口全部覆盖，各走各自的 API 重载：

| 来源 | 重载方式 |
|---|---|
| 歌单 | `playlistDetail` + 分页补齐（`/v6/playlist/detail` 只返回首页曲目） |
| 专辑 | `album(id:)` |
| 歌手 | `artist(id:)` 热门单曲 |
| 每日推荐 | `dailyRecommendSongs()` |
| 音乐云盘 | `cloudSongs()` |
| 最近播放 | `playRecords(uid:)` |
| 心动模式 | 重取随机 seed 走 `intelligenceList` |
| 私人漫游 | `startFM()` |

心动模式与私人漫游是**重新生成**而非恢复原队列——它们本就不是固定歌单，这符合其自身语义。

### 为什么 `PlayContext` 与 `PlaySource` 分开

一开始我试着从 `PlaySource` 推导来源，行不通：

- **心动模式**的 `source` 是 `.playlist(喜欢的音乐)`，这是 scrobble 归属所需的正确值，但作为「来源」它是「心动模式」而不是「我喜欢的音乐」；
- **最近播放页**的 `source` 是 `.none`，没有任何 id，无论如何都推导不出来。

所以来源由各调用点显式传入，与 `source` 解耦。

去重按 `kind + id` 而非标题，歌单改名后仍是同一条记录，不会累积成两行。

### 顺带修掉的一个持久化 bug

`restoreState()` 里最近播放的恢复原本被挡在 `!state.queue.isEmpty` 这个 guard 之后。播放队列一旦为空，历史完全不恢复，而下一次播放触发的 `persistState()` 又会把空列表写回文件——记录**永久**丢失。现在 recents 的恢复独立于队列。恢复路径同时做截断，避免旧状态文件里的更长列表绕过上限。

实测（改状态文件 + AX 读取真实菜单项）：
- `queue: []` + 3 条历史 → 重启后菜单里 3 条完整恢复；
- 写入 8 条 → 重启后菜单只显示 6 条。

## 2. 沉浸式播放页顶部空白

该页面通过 `.toolbar(.hidden, for: .windowToolbar)` 隐藏了窗口工具栏，但 SwiftUI 仍然为它保留安全区域，于是整个布局（含收起按钮）从窗口顶部往下推了一个工具栏的高度——实测收起按钮距窗口顶边约 68pt，而代码里写的是 16pt。

修复为**仅在 macOS 上**忽略安全区域：iOS 上那块内边距是状态栏 / 灵动岛，一并忽略会让收起按钮钻到时钟底下。

同时统一按钮四边间距为 20pt（此前上 16pt / 左 20pt，两边不一致，视觉上不适）。

## 备注

- 本 PR 与 #23 相互独立，均从 `main` 分出，但**两者都在 CHANGELOG 顶部插入了 `0.3.4` 段落，合并时会在该处冲突**。先合任意一个，另一个 rebase 时把条目并进同一个 `0.3.4` 段落即可。
- 循环模式三态（不循环 / 列表循环 / 单曲循环）用子菜单而非单个勾选项，因为一个 checkmark 表达不了三态。新增的三个字符串已补 `en.lproj` 翻译。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
