### PR TITLE
feat(lyrics): 日文歌词显示罗马音（罗马音 / 原文 / 翻译三层）

### DIFF
--- a/Sources/Kumone/Core/Models/LyricsParser.swift
+++ b/Sources/Kumone/Core/Models/LyricsParser.swift
@@ -105,6 +105,18 @@ enum LyricsParser {
         merge(response.tlyric?.lyric, into: \.translation)
         merge(response.romalrc?.lyric, into: \.romaji)
 
+        // Romaji is only meaningful for Japanese lyrics: fill the gaps Netease
+        // left, and drop stray annotations on everything else.
+        if RomajiTranscriber.isJapanese(lines.map(\.text)) {
+            for i in lines.indices where lines[i].romaji == nil {
+                lines[i].romaji = RomajiTranscriber.transcribe(lines[i].text)
+            }
+        } else {
+            for i in lines.indices {
+                lines[i].romaji = nil
+            }
+        }
+
         out.lines = lines
         return out
     }

--- a/Sources/Kumone/Core/Models/RomajiTranscriber.swift
+++ b/Sources/Kumone/Core/Models/RomajiTranscriber.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Romaji support for Japanese lyrics.
+///
+/// Netease ships a hand-checked `romalrc` for popular tracks only, so anything
+/// off the beaten path falls back to the system tokenizer's Latin
+/// transcription — offline, dependency-free, and good enough for singing along
+/// (personal names and unusual readings can still be wrong).
+enum RomajiTranscriber {
+    private static let kanaRanges: [ClosedRange<UInt32>] = [
+        0x3040...0x309F,  // hiragana
+        0x30A0...0x30FF,  // katakana
+        0xFF66...0xFF9D,  // halfwidth katakana
+    ]
+
+    static func containsKana(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            kanaRanges.contains { $0.contains(scalar.value) }
+        }
+    }
+
+    /// Whether a lyric body reads as Japanese. Requires more than an isolated
+    /// katakana loanword so Chinese lyrics don't get spuriously annotated.
+    static func isJapanese(_ texts: [String]) -> Bool {
+        let candidates = texts.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !candidates.isEmpty else { return false }
+        let kanaLines = candidates.count(where: containsKana)
+        return kanaLines >= 3 || Double(kanaLines) / Double(candidates.count) >= 0.2
+    }
+
+    /// Latin transcription via the system tokenizer. Returns nil when the input
+    /// yields nothing beyond what it already was (pure Latin, punctuation).
+    static func transcribe(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        let source = trimmed as CFString
+        let range = CFRangeMake(0, CFStringGetLength(source))
+        let tokenizer = CFStringTokenizerCreate(
+            kCFAllocatorDefault, source, range,
+            kCFStringTokenizerUnitWordBoundary,
+            Locale(identifier: "ja_JP") as CFLocale)
+
+        var pieces: [String] = []
+        var transcribedAny = false
+        while CFStringTokenizerAdvanceToNextToken(tokenizer) != [] {
+            let tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer)
+            let original = CFStringCreateWithSubstring(kCFAllocatorDefault, source, tokenRange)
+                as String? ?? ""
+            if let latin = CFStringTokenizerCopyCurrentTokenAttribute(
+                tokenizer, kCFStringTokenizerAttributeLatinTranscription) as? String,
+                !latin.isEmpty
+            {
+                pieces.append(latin)
+                transcribedAny = true
+            } else if !original.trimmingCharacters(in: .whitespaces).isEmpty {
+                pieces.append(original)
+            }
+        }
+
+        guard transcribedAny else { return nil }
+        let romaji = pieces.joined(separator: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
+        // Latin-only lines transcribe to themselves — don't echo the lyric.
+        guard !romaji.isEmpty, !isEquivalent(romaji, trimmed) else { return nil }
+        return romaji
+    }
+
+    private static func isEquivalent(_ lhs: String, _ rhs: String) -> Bool {
+        func squash(_ s: String) -> String {
+            s.lowercased().filter { !$0.isWhitespace }
+        }
+        return squash(lhs) == squash(rhs)
+    }
+}

--- a/Sources/Kumone/Core/Storage/SettingsManager.swift
+++ b/Sources/Kumone/Core/Storage/SettingsManager.swift
@@ -60,6 +60,7 @@ final class SettingsManager: ObservableObject {
         static let quality = "settings.audioQuality"
         static let appearance = "settings.appearance"
         static let showTranslation = "settings.showLyricsTranslation"
+        static let showRomaji = "settings.showLyricsRomaji"
         static let volume = "settings.volume"
         static let fmMode = "settings.fmMode"
         static let unblock = "settings.enableUnblock"
@@ -78,6 +79,11 @@ final class SettingsManager: ObservableObject {
         didSet { UserDefaults.standard.set(showLyricsTranslation, forKey: Keys.showTranslation) }
     }
 
+    /// Romaji line above Japanese lyrics.
+    @Published var showLyricsRomaji: Bool {
+        didSet { UserDefaults.standard.set(showLyricsRomaji, forKey: Keys.showRomaji) }
+    }
+
     /// Resolve gray tracks from third-party sources (UnblockNeteaseMusic-style).
     @Published var enableUnblock: Bool {
         didSet { UserDefaults.standard.set(enableUnblock, forKey: Keys.unblock) }
@@ -93,6 +99,7 @@ final class SettingsManager: ObservableObject {
         audioQuality = defaults.string(forKey: Keys.quality).flatMap(AudioQuality.init) ?? .exhigh
         appearance = defaults.string(forKey: Keys.appearance).flatMap(AppAppearance.init) ?? .auto
         showLyricsTranslation = defaults.object(forKey: Keys.showTranslation) as? Bool ?? true
+        showLyricsRomaji = defaults.object(forKey: Keys.showRomaji) as? Bool ?? false
         enableUnblock = defaults.object(forKey: Keys.unblock) as? Bool ?? true
         showDesktopLyrics = defaults.object(forKey: Keys.desktopLyrics) as? Bool ?? false
     }

--- a/Sources/Kumone/Features/Pages/SettingsView.swift
+++ b/Sources/Kumone/Features/Pages/SettingsView.swift
@@ -29,6 +29,10 @@ struct SettingsView: View {
                     }
                 }
                 Toggle("显示歌词翻译", isOn: $settings.showLyricsTranslation)
+                Toggle("显示日文歌词罗马音", isOn: $settings.showLyricsRomaji)
+                Text("日文歌词上方显示罗马音，缺少官方罗马音时自动生成读音")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 #if os(macOS)
                 Toggle("桌面歌词", isOn: $settings.showDesktopLyrics)
                 Text("在屏幕上悬浮显示当前歌词，可拖动调整位置")

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -379,6 +379,11 @@ struct NowPlayingView: View {
             player.seek(to: line.time)
         } label: {
             VStack(alignment: .leading, spacing: 5) {
+                if settings.showLyricsRomaji, let romaji = line.romaji {
+                    Text(romaji)
+                        .font(.system(size: isActive ? 15 : 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                }
                 Text(line.text.isEmpty ? "♪" : line.text)
                     .font(.system(size: isActive ? 26 : 20, weight: isActive ? .bold : .semibold))
                     .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))

--- a/Sources/Kumone/Features/Player/Panels.swift
+++ b/Sources/Kumone/Features/Player/Panels.swift
@@ -114,6 +114,11 @@ struct LyricsPanel: View {
             player.seek(to: line.time)
         } label: {
             VStack(alignment: .leading, spacing: 3) {
+                if settings.showLyricsRomaji, let romaji = line.romaji {
+                    Text(romaji)
+                        .font(.system(size: isActive ? 12 : 11))
+                        .foregroundStyle(isActive ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+                }
                 Text(line.text.isEmpty ? "♪" : line.text)
                     .font(.system(size: isActive ? 16 : 14, weight: isActive ? .bold : .medium))
                     .foregroundStyle(isActive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))


### PR DESCRIPTION
## 背景

日文歌词目前只展示原文与翻译。这个 PR 在原文上方补一层罗马音，最终顺序为 **罗马音 → 日文原文 → 翻译**。

## 实现

- **数据来源**：`/song/lyric` 请求本就带了 `rv: -1`，`LyricLine.romaji` 也已经在解析 `romalrc`，只是从未渲染。网易云的 `romalrc` 是人工校对的，但只覆盖热门曲目，冷门日文歌基本没有。
- **兜底生成**：缺失时用系统 `CFStringTokenizer` 的 `kCFStringTokenizerAttributeLatinTranscription`（locale `ja_JP`）本地生成读法 —— 离线、零依赖、不引入新的第三方库。人名与特殊读法仍可能出错，属于可接受的降级。
- **触发门槛**：仅当歌词整体判定为日文（含假名的行 ≥ 3 或占比 ≥ 20%）才生成并显示，中文歌不会被误注音；判定不通过时连 `romalrc` 带来的 `romaji` 也一并清空，UI 侧只需判空。
- **避免回显**：日文歌里夹杂的纯拉丁行转写结果与原文等价，直接丢弃，不重复显示同一行。

## UI

- 全屏 Now Playing 大歌词、右侧歌词面板两处渲染罗马音，字号与不透明度同翻译层级（大歌词 15/13，面板 12/11）。
- 桌面歌词悬浮胶囊**未改动** —— 加第三行会让胶囊明显变高。
- 设置 → 外观新增「显示日文歌词罗马音」开关，**默认关闭**，附说明文案。

## 备注

本地生成的长音使用标准 Hepburn 的 macron（如 `tēze`），与部分 `romalrc` 贡献者手写的 `ou` / `uu` 风格不同。考虑到 `romalrc` 自身写法本就不统一，未做归一化处理。

## 验证

`swift build` 通过；本地打包运行，日文曲目三层歌词显示正常，中文曲目无罗马音行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134c5GXv5HxoQXEMe8HcPMx
