### PR TITLE
feat(ios): add immersive playback and Liquid Glass mini player

### DIFF
--- a/Sources/Kumone/Core/Storage/SettingsManager.swift
+++ b/Sources/Kumone/Core/Storage/SettingsManager.swift
@@ -52,6 +52,22 @@ enum AppAppearance: String, CaseIterable, Identifiable {
     }
 }
 
+#if os(iOS)
+enum NowPlayingMode: String, CaseIterable, Identifiable {
+    case classic
+    case immersive
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .classic: return String(localized: "经典模式")
+        case .immersive: return String(localized: "沉浸模式")
+        }
+    }
+}
+#endif
+
 @MainActor
 final class SettingsManager: ObservableObject {
     static let shared = SettingsManager()
@@ -59,6 +75,9 @@ final class SettingsManager: ObservableObject {
     private enum Keys {
         static let quality = "settings.audioQuality"
         static let appearance = "settings.appearance"
+        #if os(iOS)
+        static let nowPlayingMode = "settings.nowPlayingMode"
+        #endif
         static let showTranslation = "settings.showLyricsTranslation"
         static let showRomaji = "settings.showLyricsRomaji"
         static let volume = "settings.volume"
@@ -74,6 +93,12 @@ final class SettingsManager: ObservableObject {
     @Published var appearance: AppAppearance {
         didSet { UserDefaults.standard.set(appearance.rawValue, forKey: Keys.appearance) }
     }
+
+    #if os(iOS)
+    @Published var nowPlayingMode: NowPlayingMode {
+        didSet { UserDefaults.standard.set(nowPlayingMode.rawValue, forKey: Keys.nowPlayingMode) }
+    }
+    #endif
 
     @Published var showLyricsTranslation: Bool {
         didSet { UserDefaults.standard.set(showLyricsTranslation, forKey: Keys.showTranslation) }
@@ -98,6 +123,9 @@ final class SettingsManager: ObservableObject {
         let defaults = UserDefaults.standard
         audioQuality = defaults.string(forKey: Keys.quality).flatMap(AudioQuality.init) ?? .exhigh
         appearance = defaults.string(forKey: Keys.appearance).flatMap(AppAppearance.init) ?? .auto
+        #if os(iOS)
+        nowPlayingMode = defaults.string(forKey: Keys.nowPlayingMode).flatMap(NowPlayingMode.init) ?? .immersive
+        #endif
         showLyricsTranslation = defaults.object(forKey: Keys.showTranslation) as? Bool ?? true
         showLyricsRomaji = defaults.object(forKey: Keys.showRomaji) as? Bool ?? false
         enableUnblock = defaults.object(forKey: Keys.unblock) as? Bool ?? true

--- a/Sources/Kumone/Features/IOSMainWindow.swift
+++ b/Sources/Kumone/Features/IOSMainWindow.swift
@@ -7,7 +7,7 @@ public struct IOSMainWindow: View {
     @StateObject private var settings = SettingsManager.shared
     @StateObject private var toasts = ToastCenter.shared
     @StateObject private var updater = IOSUpdater.shared
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Namespace private var nowPlayingTransition
 
     @State private var selectedTab: IOSTab = .home
     @State private var showLogin = false
@@ -19,110 +19,180 @@ public struct IOSMainWindow: View {
 
     public init() {}
 
-    /// iOS 26+ renders its own Liquid Glass tab bar — use it. Older systems
-    /// get our simulated-glass custom bar instead.
-    private var usesNativeTabBar: Bool {
-        if #available(iOS 26.0, *) { true } else { false }
+    public var body: some View {
+        presentationRoot
+            .environmentObject(player)
+            .environmentObject(account)
+            .environmentObject(settings)
+            .environmentObject(toasts)
+            .tint(Theme.accent)
+            .preferredColorScheme(settings.appearance.colorScheme)
+            .environment(\.openLogin, { showLogin = true })
+            .task {
+                await account.bootstrap()
+                IOSUpdater.shared.check(interactive: false)
+            }
+            .sheet(isPresented: $updater.showSheet) {
+                IOSUpdaterSheet()
+            }
+            .sheet(isPresented: $showLogin) {
+                LoginSheet()
+                    .environmentObject(account)
+                    .environmentObject(toasts)
+            }
+            .overlay(alignment: .top) {
+                if let toast = toasts.current {
+                    ToastView(toast: toast)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .padding(.top, 8)
+                }
+            }
+            .animation(.spring(duration: 0.3), value: toasts.current)
     }
 
-    private func popToRoot(_ tab: IOSTab) {
-        switch tab {
-        case .home: homePath = NavigationPath()
-        case .explore: explorePath = NavigationPath()
-        case .fm: fmPath = NavigationPath()
-        case .search: searchPath = NavigationPath()
-        case .library: libraryPath = NavigationPath()
+    @ViewBuilder
+    private var presentationRoot: some View {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            if #available(iOS 18.0, *) {
+                zoomNowPlayingRoot
+            } else {
+                legacyPresentationRoot
+            }
+        } else {
+            systemNowPlayingRoot
         }
     }
 
-    public var body: some View {
-        Group {
-            if UIDevice.current.userInterfaceIdiom == .pad {
-                // iPad / Large screen: Split view
-                MainWindow()
-            } else {
-                // iPhone / Compact screen: Tab view
-                tabInterface
+    private var systemNowPlayingRoot: some View {
+        appContent
+            .fullScreenCover(isPresented: $player.showNowPlaying) {
+                systemNowPlayingPresentation
+            }
+    }
+
+    @available(iOS 18.0, *)
+    private var zoomNowPlayingRoot: some View {
+        appContent
+            .fullScreenCover(isPresented: $player.showNowPlaying) {
+                systemNowPlayingPresentation
+                    .navigationTransition(
+                        .zoom(
+                            sourceID: NowPlayingTransitionID.surface,
+                            in: nowPlayingTransition
+                        )
+                    )
+            }
+    }
+
+    @ViewBuilder
+    private var systemNowPlayingPresentation: some View {
+        if #available(iOS 16.4, *) {
+            nowPlayingPresentation(
+                usesSystemInteractiveDismissal: true,
+                dismissAnimation: nil
+            )
+            .presentationBackground(.clear)
+        } else {
+            nowPlayingPresentation(
+                usesSystemInteractiveDismissal: true,
+                dismissAnimation: nil
+            )
+        }
+    }
+
+    private var legacyPresentationRoot: some View {
+        ZStack {
+            appContent
+
+            if player.showNowPlaying {
+                nowPlayingPresentation(
+                    usesSystemInteractiveDismissal: false,
+                    dismissAnimation: NowPlayingPresentationMetrics.presentationAnimation
+                )
+                .matchedGeometryEffect(
+                    id: NowPlayingTransitionID.surface,
+                    in: nowPlayingTransition,
+                    properties: .frame,
+                    anchor: .bottom,
+                    isSource: false
+                )
+                .transition(.identity)
+                .zIndex(1)
             }
         }
-        .environmentObject(player)
-        .environmentObject(account)
-        .environmentObject(settings)
-        .environmentObject(toasts)
-        .tint(Theme.accent)
-        .preferredColorScheme(settings.appearance.colorScheme)
-        .environment(\.openLogin, { showLogin = true })
-        .task {
-            await account.bootstrap()
-            // Quiet auto-check on launch: only surfaces a sheet if newer.
-            IOSUpdater.shared.check(interactive: false)
+    }
+
+    @ViewBuilder
+    private var appContent: some View {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            MainWindow()
+        } else {
+            tabInterface
         }
-        .sheet(isPresented: $updater.showSheet) {
-            IOSUpdaterSheet()
-        }
-        .sheet(isPresented: $showLogin) {
-            LoginSheet()
-                .environmentObject(account)
-                .environmentObject(toasts)
-        }
-        .fullScreenCover(isPresented: $player.showNowPlaying) {
+    }
+
+    private func nowPlayingPresentation(
+        usesSystemInteractiveDismissal: Bool,
+        dismissAnimation: Animation?
+    ) -> some View {
+        IOSNowPlayingPresentation(
+            isPresented: $player.showNowPlaying,
+            mode: settings.nowPlayingMode,
+            usesSystemInteractiveDismissal: usesSystemInteractiveDismissal,
+            dismissAnimation: dismissAnimation
+        ) {
             NowPlayingView()
                 .environmentObject(player)
                 .environmentObject(account)
                 .environmentObject(settings)
         }
-        .overlay(alignment: .top) {
-            if let toast = toasts.current {
-                ToastView(toast: toast)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .padding(.top, 8)
-            }
-        }
-        .animation(.spring(duration: 0.3), value: toasts.current)
     }
 
     @ViewBuilder
     private var tabInterface: some View {
-        if usesNativeTabBar {
-            nativeTabInterface
+        if #available(iOS 26.0, *) {
+            iOS26TabView
+                .tabBarMinimizeBehavior(.onScrollDown)
+                .tabViewBottomAccessory {
+                    if player.hasCurrentTrack {
+                        IOSMiniPlayerAccessory(
+                            transitionNamespace: nowPlayingTransition
+                        )
+                    }
+                }
+                .animation(AppAnimation.standard, value: player.hasCurrentTrack)
         } else {
             customTabInterface
         }
     }
 
-    /// iOS 26+: the system TabView renders the real Liquid Glass bar.
-    private var nativeTabInterface: some View {
-        ZStack(alignment: .bottom) {
-            TabView(selection: $selectedTab) {
+    @available(iOS 26.0, *)
+    private var iOS26TabView: some View {
+        TabView(selection: $selectedTab) {
+            Tab("推荐", systemImage: "house", value: .home) {
                 tabStack(.home) { HomeView() }
-                    .tabItem { Label("推荐", systemImage: "house.fill") }
-                    .tag(IOSTab.home)
-                tabStack(.explore) { ExploreView() }
-                    .tabItem { Label("精选", systemImage: "square.grid.2x2.fill") }
-                    .tag(IOSTab.explore)
-                tabStack(.fm) { FMView() }
-                    .tabItem { Label("漫游", systemImage: "wave.3.right.circle.fill") }
-                    .tag(IOSTab.fm)
-                tabStack(.search) { SearchView(query: "") }
-                    .tabItem { Label("搜索", systemImage: "magnifyingglass") }
-                    .tag(IOSTab.search)
-                tabStack(.library) { IOSLibraryView(showLogin: $showLogin) }
-                    .tabItem { Label("我的", systemImage: "person.crop.circle.fill") }
-                    .tag(IOSTab.library)
             }
-            if player.hasCurrentTrack {
-                IOSMiniPlayerBar()
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 58)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+
+            Tab("精选", systemImage: "square.grid.2x2", value: .explore) {
+                tabStack(.explore) { ExploreView() }
+            }
+
+            Tab("漫游", systemImage: "wave.3.right.circle", value: .fm) {
+                tabStack(.fm) { FMView() }
+            }
+
+            Tab("我的", systemImage: "person.crop.circle", value: .library) {
+                tabStack(.library) { IOSLibraryView(showLogin: $showLogin) }
+            }
+
+            Tab(value: .search, role: .search) {
+                tabStack(.search) { SearchView(query: "") }
+            } label: {
+                Label("搜索", systemImage: "magnifyingglass")
             }
         }
-        .animation(AppAnimation.standard, value: player.hasCurrentTrack)
     }
 
-    /// iOS 16–25: a manual container (no system TabView) so there is exactly
-    /// one — our simulated-glass — tab bar. All five stacks stay alive to
-    /// preserve their navigation state; only the selected one is shown.
     private var customTabInterface: some View {
         ZStack(alignment: .bottom) {
             ZStack {
@@ -135,10 +205,12 @@ public struct IOSMainWindow: View {
 
             VStack(spacing: 8) {
                 if player.hasCurrentTrack {
-                    IOSMiniPlayerBar()
+                    IOSMiniPlayerBar(presentation: .legacyOverlay)
+                        .nowPlayingTransitionSource(in: nowPlayingTransition)
                         .padding(.horizontal, 12)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
+
                 GlassTabBar(items: Self.tabItems, selection: $selectedTab) { tab in
                     popToRoot(tab)
                 }
@@ -148,15 +220,31 @@ public struct IOSMainWindow: View {
         .animation(AppAnimation.standard, value: player.hasCurrentTrack)
     }
 
+    private func popToRoot(_ tab: IOSTab) {
+        switch tab {
+        case .home: homePath = NavigationPath()
+        case .explore: explorePath = NavigationPath()
+        case .fm: fmPath = NavigationPath()
+        case .search: searchPath = NavigationPath()
+        case .library: libraryPath = NavigationPath()
+        }
+    }
+
     @ViewBuilder
-    private func tabStack<Content: View>(_ tab: IOSTab, @ViewBuilder _ content: () -> Content) -> some View {
+    private func tabStack<Content: View>(
+        _ tab: IOSTab,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
         NavigationStack(path: binding(for: tab)) {
             content().appDestinations()
         }
     }
 
     @ViewBuilder
-    private func page<Content: View>(_ tab: IOSTab, @ViewBuilder _ content: () -> Content) -> some View {
+    private func page<Content: View>(
+        _ tab: IOSTab,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
         content()
             .opacity(selectedTab == tab ? 1 : 0)
             .allowsHitTesting(selectedTab == tab)
@@ -188,68 +276,211 @@ extension IOSMainWindow {
     ]
 }
 
+private enum NowPlayingTransitionID {
+    static let surface = "now-playing-surface"
+}
+
 // MARK: - Mini player bar for iOS
 
-struct IOSMiniPlayerBar: View {
-    @EnvironmentObject private var player: PlayerService
-    @StateObject private var updater = IOSUpdater.shared
-    @EnvironmentObject private var account: AccountStore
+@available(iOS 26.0, *)
+private struct IOSMiniPlayerAccessory: View {
+    @Environment(\.tabViewBottomAccessoryPlacement) private var placement
+    let transitionNamespace: Namespace.ID
 
     var body: some View {
-        Button {
-            withAnimation(AppAnimation.smooth) {
-                player.showNowPlaying = true
-            }
-        } label: {
-            HStack(spacing: 10) {
-                CachedAsyncImage(url: player.currentTrack?.album.picUrl?.resizedImageURL(128))
-                    .frame(width: 42, height: 42)
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
-                    .shadow(color: .black.opacity(0.15), radius: 4, y: 1)
+        IOSMiniPlayerBar(presentation: presentation)
+            // Match the complete system accessory, never only its artwork.
+            .nowPlayingTransitionSource(in: transitionNamespace)
+    }
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(player.currentTrack?.name ?? "")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                    Text(player.currentTrack?.artistNames ?? "")
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+    private var presentation: IOSMiniPlayerBar.Presentation {
+        let placementIsInline = placement.map { $0 == .inline }
+        return NowPlayingPresentationMetrics.shouldUseInlineMiniPlayerLayout(
+            placementIsInline: placementIsInline
+        ) ? .inlineAccessory : .bottomAccessory
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func nowPlayingTransitionSource(in namespace: Namespace.ID) -> some View {
+        if #available(iOS 18.0, *) {
+            matchedTransitionSource(
+                id: NowPlayingTransitionID.surface,
+                in: namespace
+            )
+        } else {
+            matchedGeometryEffect(
+                id: NowPlayingTransitionID.surface,
+                in: namespace,
+                properties: .frame,
+                anchor: .bottom,
+                isSource: true
+            )
+        }
+    }
+}
+
+/// Renders mini-player content inside either a system-owned tab accessory or
+/// the material-backed compatibility overlay used before iOS 26.
+///
+/// Do not add a background for `bottomAccessory` or `inlineAccessory`: the
+/// tab view owns their Liquid Glass surface and adding another material creates
+/// a visibly nested card.
+struct IOSMiniPlayerBar: View {
+    enum Presentation {
+        case bottomAccessory
+        case inlineAccessory
+        case legacyOverlay
+
+        var isInline: Bool { self == .inlineAccessory }
+        var drawsBackground: Bool { self == .legacyOverlay }
+    }
+
+    @EnvironmentObject private var player: PlayerService
+    let presentation: Presentation
+
+    var body: some View {
+        playerBarSurface
+            .simultaneousGesture(expandGesture)
+    }
+
+    @ViewBuilder
+    private var playerBarSurface: some View {
+        if presentation.drawsBackground {
+            content
+                .background(.regularMaterial, in: Capsule())
+                .overlay {
+                    Capsule()
+                        .strokeBorder(.primary.opacity(0.08), lineWidth: 0.5)
                 }
+                .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+        } else {
+            content
+        }
+    }
 
-                Spacer(minLength: 0)
+    private var content: some View {
+        HStack(spacing: 4) {
+            Button(action: showNowPlaying) {
+                trackSummary
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(nowPlayingAccessibilityLabel)
+            .accessibilityHint("打开正在播放")
 
-                Button {
-                    player.togglePlayPause()
-                } label: {
-                    Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(.primary)
-                        .frame(width: 34, height: 34)
+            if !presentation.isInline {
+                Button(action: player.previous) {
+                    Image(systemName: "backward.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.pressable)
+                .disabled(player.isFMMode)
+                .opacity(player.isFMMode ? 0.35 : 1)
+                .accessibilityLabel("上一首")
+            }
 
-                Button {
-                    player.next()
-                } label: {
+            Button(action: player.togglePlayPause) {
+                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.pressable)
+            .accessibilityLabel(player.isPlaying ? "暂停" : "播放")
+
+            if !presentation.isInline {
+                Button(action: player.next) {
                     Image(systemName: "forward.fill")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.secondary)
-                        .frame(width: 34, height: 34)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.pressable)
+                .accessibilityLabel("下一首")
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 7)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .strokeBorder(.primary.opacity(0.08), lineWidth: 0.5)
-            )
-            .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
         }
-        .buttonStyle(.plain)
+        .padding(.leading, 12)
+        .padding(.trailing, 6)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var trackSummary: some View {
+        HStack(alignment: .top, spacing: 8) {
+            CachedAsyncImage(url: player.currentTrack?.album.picUrl?.resizedImageURL(128))
+                .frame(
+                    width: artworkSize,
+                    height: artworkSize
+                )
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 1)
+
+            VStack(alignment: .leading, spacing: metadataSpacing) {
+                Text(player.currentTrack?.name ?? "")
+                    .font(titleFont)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text(player.currentTrack?.artistNames ?? "")
+                    .font(artistFont)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .contentShape(Rectangle())
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var artworkSize: CGFloat {
+        presentation.isInline ? 28 : 32
+    }
+
+    private var titleFont: Font {
+        .system(size: presentation.isInline ? 10 : 13, weight: .semibold)
+    }
+
+    private var artistFont: Font {
+        .system(size: presentation.isInline ? 8 : 10)
+    }
+
+    private var metadataSpacing: CGFloat {
+        presentation.isInline ? 2 : 3
+    }
+
+    private var nowPlayingAccessibilityLabel: String {
+        let title = player.currentTrack?.name ?? String(localized: "正在播放")
+        guard let artist = player.currentTrack?.artistNames, !artist.isEmpty else {
+            return title
+        }
+        return "\(title)，\(artist)"
+    }
+
+    private var expandGesture: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .onEnded { value in
+                guard NowPlayingPresentationMetrics.shouldExpandFromMiniPlayer(
+                    translation: value.translation.height,
+                    predictedTranslation: value.predictedEndTranslation.height
+                ) else { return }
+                showNowPlaying()
+            }
+    }
+
+    private func showNowPlaying() {
+        if #available(iOS 18.0, *) {
+            player.showNowPlaying = true
+        } else {
+            withAnimation(NowPlayingPresentationMetrics.presentationAnimation) {
+                player.showNowPlaying = true
+            }
+        }
     }
 }
 

--- a/Sources/Kumone/Features/Pages/SettingsView.swift
+++ b/Sources/Kumone/Features/Pages/SettingsView.swift
@@ -28,6 +28,13 @@ struct SettingsView: View {
                         Text(appearance.displayName).tag(appearance)
                     }
                 }
+                #if os(iOS)
+                Picker("播放页模式", selection: $settings.nowPlayingMode) {
+                    ForEach(NowPlayingMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                #endif
                 Toggle("显示歌词翻译", isOn: $settings.showLyricsTranslation)
                 Toggle("显示日文歌词罗马音", isOn: $settings.showLyricsRomaji)
                 Text("日文歌词上方显示罗马音，缺少官方罗马音时自动生成读音")

--- a/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+#if os(iOS)
+/// Shared geometry and interaction constants for the iPhone Now Playing
+/// presentation. Keeping these values together makes the relationship between
+/// the drag indicator and the track header explicit and regression-testable.
+enum NowPlayingPresentationMetrics {
+    /// The compact layout starts at the safe-area edge, which already sits
+    /// about 12pt below the Dynamic Island. One additional point produces the
+    /// same visible 13pt gap used below the indicator.
+    static let dynamicIslandSafeAreaClearance: CGFloat = 12
+    static let indicatorTopSpacing: CGFloat = 1
+    static let indicatorToHeaderSpacing: CGFloat = 13
+    static let indicatorWidth: CGFloat = 44
+    static let indicatorHeight: CGFloat = 5
+    static let indicatorHitWidth: CGFloat = 180
+    static let indicatorHitHeight: CGFloat = 82
+    static let controlsRevealHitHeight: CGFloat = 132
+    static let controlsTransitionOffset: CGFloat = 30
+    static let controlsTransitionScale: CGFloat = 0.97
+
+    /// A strong ease-out lets the lyrics reclaim space immediately, then
+    /// settles gently instead of moving at a constant speed.
+    static let controlsLayoutAnimation = Animation.timingCurve(
+        0.16, 1, 0.3, 1,
+        duration: 0.38
+    )
+    /// Motion and opacity deliberately use separate tracks. The spring gives
+    /// the controls a restrained pop while the alpha curve fades them in
+    /// quickly and eases through the final few percent.
+    static let controlsRevealMotionAnimation = Animation.spring(
+        response: 0.44,
+        dampingFraction: 0.82,
+        blendDuration: 0.08
+    )
+    static let controlsDismissMotionAnimation = Animation.timingCurve(
+        0.16, 1, 0.3, 1,
+        duration: 0.28
+    )
+    static let controlsFadeInAnimation = Animation.timingCurve(
+        0.16, 1, 0.3, 1,
+        duration: 0.24
+    )
+    static let controlsFadeOutAnimation = Animation.timingCurve(
+        0.16, 1, 0.3, 1,
+        duration: 0.18
+    )
+
+    static let dismissDistance: CGFloat = 110
+    static let dismissPrediction: CGFloat = 190
+    static let miniPlayerExpandDistance: CGFloat = 28
+    static let miniPlayerExpandPrediction: CGFloat = 72
+    static let presentationAnimation = Animation.spring(
+        response: 0.52,
+        dampingFraction: 0.9,
+        blendDuration: 0.1
+    )
+
+    static var immersiveHeaderTopInset: CGFloat {
+        indicatorTopSpacing + indicatorHeight + indicatorToHeaderSpacing
+    }
+
+    static var dynamicIslandToIndicatorSpacing: CGFloat {
+        dynamicIslandSafeAreaClearance + indicatorTopSpacing
+    }
+
+    static func shouldDismiss(
+        translation: CGFloat,
+        predictedTranslation: CGFloat
+    ) -> Bool {
+        translation > dismissDistance || predictedTranslation > dismissPrediction
+    }
+
+    static func shouldExpandFromMiniPlayer(
+        translation: CGFloat,
+        predictedTranslation: CGFloat
+    ) -> Bool {
+        translation < -miniPlayerExpandDistance
+            || predictedTranslation < -miniPlayerExpandPrediction
+    }
+
+    /// The system can briefly report no accessory placement while it reparents
+    /// the view between the expanded and inline tab-bar containers. Prefer the
+    /// compact layout during that undefined interval so a full-width player
+    /// cannot be laid out inside the inline container for a transient frame.
+    static func shouldUseInlineMiniPlayerLayout(
+        placementIsInline: Bool?
+    ) -> Bool {
+        placementIsInline ?? true
+    }
+}
+
+private struct DismissNowPlayingActionKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var dismissNowPlayingAction: (() -> Void)? {
+        get { self[DismissNowPlayingActionKey.self] }
+        set { self[DismissNowPlayingActionKey.self] = newValue }
+    }
+}
+
+/// Owns only presentation mechanics for Now Playing: the drag indicator and
+/// interactive dismissal offset. Playback layout and safe areas remain in
+/// `NowPlayingView` and SwiftUI's presentation container.
+struct IOSNowPlayingPresentation<Content: View>: View {
+    private let mode: NowPlayingMode
+    private let usesSystemInteractiveDismissal: Bool
+    private let dismissAnimation: Animation?
+    private let content: Content
+
+    @Binding private var isPresented: Bool
+    @State private var dragOffset: CGFloat = 0
+
+    init(
+        isPresented: Binding<Bool>,
+        mode: NowPlayingMode,
+        usesSystemInteractiveDismissal: Bool = false,
+        dismissAnimation: Animation? = NowPlayingPresentationMetrics.presentationAnimation,
+        @ViewBuilder content: () -> Content
+    ) {
+        _isPresented = isPresented
+        self.mode = mode
+        self.usesSystemInteractiveDismissal = usesSystemInteractiveDismissal
+        self.dismissAnimation = dismissAnimation
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let isInteractive = proxy.size.width < 720 && mode == .immersive
+            let usesCustomDrag = isInteractive && !usesSystemInteractiveDismissal
+
+            ZStack(alignment: .top) {
+                content
+                    .environment(\.dismissNowPlayingAction, dismiss)
+
+                if isInteractive {
+                    dragIndicator
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .offset(y: usesCustomDrag ? dragOffset : 0)
+        }
+    }
+
+    @ViewBuilder
+    private var dragIndicator: some View {
+        if usesSystemInteractiveDismissal {
+            dragIndicatorSurface
+                .accessibilityLabel("下拉关闭播放页")
+                .accessibilityAction(named: Text("关闭播放页"), dismiss)
+        } else {
+            dragIndicatorSurface
+                .contentShape(Rectangle())
+                .gesture(dismissGesture)
+                .accessibilityLabel("下拉关闭播放页")
+                .accessibilityAction(named: Text("关闭播放页"), dismiss)
+        }
+    }
+
+    private var dragIndicatorSurface: some View {
+        ZStack(alignment: .top) {
+            Color.clear
+
+            Capsule()
+                .fill(.white.opacity(0.38))
+                .frame(
+                    width: NowPlayingPresentationMetrics.indicatorWidth,
+                    height: NowPlayingPresentationMetrics.indicatorHeight
+                )
+                .padding(.top, NowPlayingPresentationMetrics.indicatorTopSpacing)
+        }
+        .frame(
+            width: NowPlayingPresentationMetrics.indicatorHitWidth,
+            height: NowPlayingPresentationMetrics.indicatorHitHeight
+        )
+        .accessibilityIdentifier("nowPlayingDismissIndicator")
+    }
+
+    private var dismissGesture: some Gesture {
+        // The surface itself moves during the drag. Measuring in global
+        // coordinates keeps the gesture origin fixed and prevents feedback
+        // oscillation between the finger and the moving hit target.
+        DragGesture(minimumDistance: 3, coordinateSpace: .global)
+            .onChanged { value in
+                dragOffset = max(value.translation.height, 0)
+            }
+            .onEnded { value in
+                if NowPlayingPresentationMetrics.shouldDismiss(
+                    translation: value.translation.height,
+                    predictedTranslation: value.predictedEndTranslation.height
+                ) {
+                    dismiss()
+                } else {
+                    withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
+                        dragOffset = 0
+                    }
+                }
+            }
+    }
+
+    private func dismiss() {
+        if let dismissAnimation {
+            withAnimation(dismissAnimation) {
+                isPresented = false
+            }
+        } else {
+            isPresented = false
+        }
+    }
+}
+#endif

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -7,6 +7,9 @@ struct NowPlayingView: View {
     @ObservedObject private var clock = PlayerService.shared.clock
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
+    #if os(iOS)
+    @Environment(\.dismissNowPlayingAction) private var dismissNowPlayingAction
+    #endif
 
     @State private var artworkImage: PlatformImage?
     @State private var colors: ArtworkColors = .fallback
@@ -14,6 +17,9 @@ struct NowPlayingView: View {
     @State private var isUserScrolling = false
     @State private var resumeTask: Task<Void, Never>?
     @State private var showLyricsOnMobile = false
+    #if os(iOS)
+    @State private var showQueueOnMobile = false
+    #endif
 
     var body: some View {
         GeometryReader { geo in
@@ -31,21 +37,23 @@ struct NowPlayingView: View {
             // stretch the ZStack and push the corner overlays off-screen.
             .frame(width: geo.size.width)
             .overlay(alignment: .topLeading) {
-                Button {
-                    close()
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.85))
-                        .frame(width: 36, height: 36)
-                        .background(.white.opacity(0.12), in: Circle())
+                if showsClassicChrome(isCompact: isCompact) {
+                    Button {
+                        close()
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.85))
+                            .frame(width: 36, height: 36)
+                            .background(.white.opacity(0.12), in: Circle())
+                    }
+                    .buttonStyle(.pressable)
+                    .padding(.top, 20)
+                    .padding(.leading, 20)
                 }
-                .buttonStyle(.pressable)
-                .padding(.top, 20)
-                .padding(.leading, 20)
             }
             .overlay(alignment: .topTrailing) {
-                if isCompact {
+                if isCompact, showsClassicChrome(isCompact: isCompact) {
                     Button {
                         withAnimation(AppAnimation.standard) {
                             showLyricsOnMobile.toggle()
@@ -74,6 +82,16 @@ struct NowPlayingView: View {
         .task(id: player.currentTrack?.id) {
             await loadArtwork()
         }
+        #if os(iOS)
+        .onAppear {
+            showLyricsOnMobile = settings.nowPlayingMode == .immersive
+            showQueueOnMobile = false
+        }
+        .onChange(of: settings.nowPlayingMode) { _ in
+            showLyricsOnMobile = settings.nowPlayingMode == .immersive
+            showQueueOnMobile = false
+        }
+        #endif
         #if os(macOS)
         .onExitCommand {
             close()
@@ -87,7 +105,25 @@ struct NowPlayingView: View {
     }
 
     private func close() {
+        #if os(iOS)
+        if let dismissNowPlayingAction {
+            dismissNowPlayingAction()
+        } else {
+            withAnimation(NowPlayingPresentationMetrics.presentationAnimation) {
+                player.showNowPlaying = false
+            }
+        }
+        #else
         player.showNowPlaying = false
+        #endif
+    }
+
+    private func showsClassicChrome(isCompact: Bool) -> Bool {
+        #if os(iOS)
+        return !isCompact || settings.nowPlayingMode == .classic
+        #else
+        return true
+        #endif
     }
 
     // MARK: - Backdrop
@@ -142,7 +178,21 @@ struct NowPlayingView: View {
         .padding(.vertical, size.height < 500 ? 24 : 40)
     }
 
+    @ViewBuilder
     private func compactLayout(size: CGSize) -> some View {
+        #if os(iOS)
+        switch settings.nowPlayingMode {
+        case .classic:
+            classicCompactLayout(size: size)
+        case .immersive:
+            immersiveCompactLayout(size: size)
+        }
+        #else
+        classicCompactLayout(size: size)
+        #endif
+    }
+
+    private func classicCompactLayout(size: CGSize) -> some View {
         let artworkDim = min(size.width - 64, size.height * 0.38, 300)
         return VStack(spacing: 20) {
             Spacer().frame(height: 44)
@@ -172,6 +222,148 @@ struct NowPlayingView: View {
         }
         .padding(.horizontal, 16)
     }
+
+    #if os(iOS)
+    private func immersiveCompactLayout(size: CGSize) -> some View {
+        let artworkDimension = min(size.width - 112, size.height * 0.3, 250)
+        let showsExpandedArtwork = !showLyricsOnMobile && !showQueueOnMobile
+
+        return VStack(spacing: 0) {
+            Color.clear.frame(
+                height: NowPlayingPresentationMetrics.immersiveHeaderTopInset
+            )
+
+            CompactTrackHeader(showsExpandedArtwork: showsExpandedArtwork)
+                .padding(.bottom, 14)
+
+            ZStack {
+                immersiveArtworkContent(artworkDimension: artworkDimension)
+                    .opacity(showsExpandedArtwork ? 1 : 0)
+                    .allowsHitTesting(showsExpandedArtwork)
+                    .accessibilityHidden(!showsExpandedArtwork)
+
+                if showQueueOnMobile {
+                    CompactQueueContent()
+                        .transition(.opacity)
+                } else {
+                    IOSImmersiveLyricsColumn()
+                        .opacity(showLyricsOnMobile ? 1 : 0)
+                        .allowsHitTesting(showLyricsOnMobile)
+                        .accessibilityHidden(!showLyricsOnMobile)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            immersiveControls
+        }
+        .frame(width: max(size.width - 64, 0))
+        .padding(.horizontal, 32)
+        .overlayPreferenceValue(ImmersiveArtworkFramePreferenceKey.self) { frames in
+            GeometryReader { proxy in
+                if let compactAnchor = frames[.compact],
+                   let expandedAnchor = frames[.expanded] {
+                    let compactFrame = proxy[compactAnchor]
+                    let expandedFrame = proxy[expandedAnchor]
+                    let targetFrame = showsExpandedArtwork ? expandedFrame : compactFrame
+                    let targetCenterX = showsExpandedArtwork
+                        ? size.width / 2
+                        : compactFrame.midX
+
+                    immersiveArtworkSurface(isExpanded: showsExpandedArtwork)
+                        .frame(width: targetFrame.width, height: targetFrame.height)
+                        .position(x: targetCenterX, y: targetFrame.midY)
+                        .accessibilityIdentifier("immersiveArtwork")
+                }
+            }
+            .allowsHitTesting(false)
+        }
+    }
+
+    private var immersiveControls: some View {
+        VStack(spacing: 17) {
+            NowPlayingScrubber()
+            CompactTransportControls()
+            CompactVolumeControl()
+            CompactSecondaryControls(
+                showsLyrics: showLyricsOnMobile,
+                showsQueue: showQueueOnMobile,
+                onToggleLyrics: toggleImmersiveLyrics,
+                onToggleQueue: toggleImmersiveQueue
+            )
+        }
+        .padding(.top, 14)
+        .padding(.bottom, 10)
+        .accessibilityIdentifier("immersiveControls")
+    }
+
+    private func immersiveArtworkContent(artworkDimension: CGFloat) -> some View {
+        VStack(spacing: 18) {
+            Spacer(minLength: 8)
+            Color.clear
+                .frame(width: artworkDimension, height: artworkDimension)
+                .anchorPreference(
+                    key: ImmersiveArtworkFramePreferenceKey.self,
+                    value: .bounds
+                ) { [.expanded: $0] }
+            MiniLyricsView(onOpen: showImmersiveLyrics)
+                .frame(maxWidth: .infinity, maxHeight: 96)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func immersiveArtworkSurface(isExpanded: Bool) -> some View {
+        Group {
+            if let artworkImage {
+                Image(platformImage: artworkImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Rectangle()
+                    .fill(.white.opacity(isExpanded ? 0.06 : 0.1))
+                    .overlay {
+                        Image(systemName: "music.note")
+                            .font(.system(size: isExpanded ? 48 : 18, weight: .light))
+                            .foregroundStyle(.white.opacity(isExpanded ? 0.3 : 0.45))
+                    }
+            }
+        }
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: isExpanded ? 18 : 12,
+                style: .continuous
+            )
+        )
+        .shadow(
+            color: .black.opacity(isExpanded ? 0.45 : 0.22),
+            radius: isExpanded ? 36 : 10,
+            y: isExpanded ? 18 : 4
+        )
+    }
+
+    private func toggleImmersiveLyrics() {
+        withAnimation(ImmersiveArtworkTransition.animation) {
+            if showQueueOnMobile {
+                showQueueOnMobile = false
+                showLyricsOnMobile = true
+            } else {
+                showLyricsOnMobile.toggle()
+            }
+        }
+    }
+
+    private func showImmersiveLyrics() {
+        withAnimation(ImmersiveArtworkTransition.animation) {
+            showQueueOnMobile = false
+            showLyricsOnMobile = true
+        }
+    }
+
+    private func toggleImmersiveQueue() {
+        withAnimation(ImmersiveArtworkTransition.animation) {
+            showQueueOnMobile.toggle()
+        }
+    }
+    #endif
 
     // MARK: - Views
 
@@ -431,6 +623,580 @@ struct NowPlayingView: View {
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isActive)
     }
 }
+
+#if os(iOS)
+private struct IOSImmersiveLyricsColumn: View {
+    @EnvironmentObject private var player: PlayerService
+    @ObservedObject private var clock = PlayerService.shared.clock
+    @EnvironmentObject private var settings: SettingsManager
+
+    @State private var activeIndex: Int?
+    @State private var isUserScrolling = false
+    @State private var resumeTask: Task<Void, Never>?
+
+    var body: some View {
+        Group {
+            if let lyrics = player.lyrics, !lyrics.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(alignment: .leading, spacing: 22) {
+                            Color.clear.frame(height: 72)
+                            ForEach(lyrics.lines) { line in
+                                lyricLine(line, isActive: line.id == activeIndex)
+                                    .id(line.id)
+                            }
+                            Color.clear.frame(height: 96)
+                        }
+                        .padding(.horizontal, 2)
+                    }
+                    .mask(edgeMask)
+                    .accessibilityIdentifier("syncedLyricsScroll")
+                    .onChange(of: clock.progress) { _ in
+                        let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                        guard index != activeIndex else { return }
+                        activeIndex = index
+                        guard !isUserScrolling, let index else { return }
+                        withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.38)) {
+                            proxy.scrollTo(index, anchor: .center)
+                        }
+                    }
+                    .onChange(of: player.currentTrack?.id) { _ in
+                        activeIndex = nil
+                    }
+                    .simultaneousGesture(
+                        DragGesture()
+                            .onChanged { _ in
+                                guard !isUserScrolling else { return }
+                                resumeTask?.cancel()
+                                isUserScrolling = true
+                            }
+                            .onEnded { _ in
+                                resumeTask?.cancel()
+                                resumeTask = Task {
+                                    try? await Task.sleep(for: .seconds(3))
+                                    guard !Task.isCancelled else { return }
+                                    isUserScrolling = false
+                                }
+                            }
+                    )
+                }
+            } else if player.lyrics?.isInstrumental == true {
+                VStack(spacing: 10) {
+                    Image(systemName: "music.quarternote.3")
+                        .font(.system(size: 36, weight: .light))
+                        .foregroundStyle(.white.opacity(0.4))
+                    Text("纯音乐，请欣赏")
+                        .font(.system(size: 15))
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onDisappear {
+            resumeTask?.cancel()
+        }
+    }
+
+    private var edgeMask: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .clear, location: 0),
+                .init(color: .black, location: 0.12),
+                .init(color: .black, location: 0.85),
+                .init(color: .clear, location: 1),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    private func lyricLine(_ line: LyricLine, isActive: Bool) -> some View {
+        Button {
+            player.seek(to: line.time)
+        } label: {
+            VStack(alignment: .leading, spacing: 5) {
+                if settings.showLyricsRomaji, let romaji = line.romaji {
+                    Text(romaji)
+                        .font(.system(size: isActive ? 15 : 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                }
+
+                Text(line.text.isEmpty ? "♪" : line.text)
+                    .font(.system(size: 27, weight: isActive ? .bold : .semibold))
+                    .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))
+
+                if settings.showLyricsTranslation, let translation = line.translation {
+                    Text(translation)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                }
+            }
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .scaleEffect(isActive ? 1.07 : 0.82, anchor: .leading)
+        }
+        .buttonStyle(.plain)
+        .animation(.spring(response: 0.28, dampingFraction: 0.9), value: isActive)
+    }
+}
+
+// MARK: - Compact now-playing sections
+
+private enum ImmersiveArtworkTransition {
+    /// A time-based ease-out curve stays fluid at the display's native refresh rate.
+    static let animation = Animation.timingCurve(
+        0.16,
+        1,
+        0.3,
+        1,
+        duration: 0.42
+    )
+    static let compactArtworkDimension: CGFloat = 62
+    static let compactHeaderSpacing: CGFloat = 13
+    static let expandedMetadataOffset = -(
+        compactArtworkDimension + compactHeaderSpacing
+    )
+}
+
+private enum ImmersiveArtworkFrame: Hashable {
+    case compact
+    case expanded
+}
+
+private struct ImmersiveArtworkFramePreferenceKey: PreferenceKey {
+    static var defaultValue: [ImmersiveArtworkFrame: Anchor<CGRect>] = [:]
+
+    static func reduce(
+        value: inout [ImmersiveArtworkFrame: Anchor<CGRect>],
+        nextValue: () -> [ImmersiveArtworkFrame: Anchor<CGRect>]
+    ) {
+        value.merge(nextValue(), uniquingKeysWith: { _, latest in latest })
+    }
+}
+
+private struct CompactTrackHeader: View {
+    @EnvironmentObject private var player: PlayerService
+    @EnvironmentObject private var account: AccountStore
+    @State private var showAddToPlaylist = false
+
+    let showsExpandedArtwork: Bool
+
+    var body: some View {
+        HStack(spacing: ImmersiveArtworkTransition.compactHeaderSpacing) {
+            Color.clear
+                .frame(
+                    width: ImmersiveArtworkTransition.compactArtworkDimension,
+                    height: ImmersiveArtworkTransition.compactArtworkDimension
+                )
+                .anchorPreference(
+                    key: ImmersiveArtworkFramePreferenceKey.self,
+                    value: .bounds
+                ) { [.compact: $0] }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(player.currentTrack?.name ?? "")
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    if player.currentTrack?.fee == 1 {
+                        VIPBadge()
+                    }
+                }
+                Text(player.currentTrack?.artistNames ?? "")
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.62))
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .offset(
+                x: showsExpandedArtwork
+                    ? ImmersiveArtworkTransition.expandedMetadataOffset
+                    : 0
+            )
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("immersiveTrackMetadata")
+
+            if let track = player.currentTrack {
+                let liked = account.isLiked(track.id)
+                HStack(spacing: 0) {
+                    Button {
+                        Task { await account.toggleLike(trackID: track.id) }
+                    } label: {
+                        Image(systemName: liked ? "heart.fill" : "heart")
+                            .font(.system(size: 21, weight: .medium))
+                            .foregroundStyle(liked ? Theme.accent : .white.opacity(0.88))
+                            .frame(width: 44, height: 44)
+                    }
+                    .buttonStyle(.pressable)
+                    .accessibilityLabel(liked ? "取消收藏" : "收藏")
+                    .accessibilityIdentifier("immersiveFavoriteButton")
+
+                    Menu {
+                        Button {
+                            player.addToPlayNext(track)
+                        } label: {
+                            Label("下一首播放", systemImage: "text.line.first.and.arrowtriangle.forward")
+                        }
+
+                        Button {
+                            showAddToPlaylist = true
+                        } label: {
+                            Label("加入歌单…", systemImage: "music.note.list")
+                        }
+
+                        Divider()
+
+                        Button {
+                            Platform.copyToPasteboard(
+                                string: "https://music.163.com/#/song?id=\(track.id)"
+                            )
+                            ToastCenter.shared.show(String(localized: "链接已复制"))
+                        } label: {
+                            Label("复制链接", systemImage: "link")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 21, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.88))
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.pressable)
+                    .accessibilityLabel("更多操作")
+                    .accessibilityIdentifier("immersiveMoreMenu")
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .sheet(isPresented: $showAddToPlaylist) {
+            if let track = player.currentTrack {
+                AddToPlaylistSheet(track: track)
+            }
+        }
+    }
+}
+
+private struct CompactTransportControls: View {
+    @EnvironmentObject private var player: PlayerService
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: player.isFMMode ? player.fmTrash : player.previous) {
+                Image(systemName: player.isFMMode ? "trash" : "backward.fill")
+                    .font(.system(size: 25, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 58)
+            }
+            .accessibilityLabel(player.isFMMode ? "不喜欢" : "上一首")
+
+            Button(action: player.togglePlayPause) {
+                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 36, weight: .bold))
+                    .contentTransition(.opacity)
+                    .frame(maxWidth: .infinity, minHeight: 64)
+            }
+            .accessibilityLabel(player.isPlaying ? "暂停" : "播放")
+
+            Button(action: player.next) {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 25, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 58)
+            }
+            .accessibilityLabel("下一首")
+        }
+        .foregroundStyle(.white)
+        .buttonStyle(.pressable)
+    }
+}
+
+private struct CompactVolumeControl: View {
+    @EnvironmentObject private var player: PlayerService
+    @State private var isHovering = false
+    @State private var isDragging = false
+
+    var body: some View {
+        HStack(spacing: 11) {
+            Image(systemName: "speaker.fill")
+                .font(.caption2)
+            GeometryReader { geo in
+                TranslucentSliderTrack(
+                    fraction: CGFloat(player.volume),
+                    isActive: isHovering || isDragging
+                )
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            isDragging = true
+                            updateVolume(at: value.location.x, width: geo.size.width)
+                        }
+                        .onEnded { value in
+                            updateVolume(at: value.location.x, width: geo.size.width)
+                            isDragging = false
+                        }
+                )
+            }
+            .frame(height: 24)
+            .onHover { hovering in
+                withAnimation(AppAnimation.quick) { isHovering = hovering }
+            }
+            .accessibilityElement()
+            .accessibilityLabel("音量")
+            .accessibilityValue("\(Int((player.volume * 100).rounded()))%")
+            .accessibilityAdjustableAction(adjustVolume)
+            Image(systemName: "speaker.wave.3.fill")
+                .font(.caption)
+        }
+        .foregroundStyle(.white.opacity(0.7))
+    }
+
+    private func updateVolume(at location: CGFloat, width: CGFloat) {
+        guard width > 0 else { return }
+        player.volume = Float(min(max(location / width, 0), 1))
+    }
+
+    private func adjustVolume(_ direction: AccessibilityAdjustmentDirection) {
+        let step: Float = 0.05
+        switch direction {
+        case .increment:
+            player.volume = min(player.volume + step, 1)
+        case .decrement:
+            player.volume = max(player.volume - step, 0)
+        @unknown default:
+            break
+        }
+    }
+}
+
+private struct CompactSecondaryControls: View {
+    @EnvironmentObject private var player: PlayerService
+    let showsLyrics: Bool
+    let showsQueue: Bool
+    let onToggleLyrics: () -> Void
+    let onToggleQueue: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            secondaryButton(
+                icon: showsLyrics && !showsQueue ? "quote.bubble.fill" : "quote.bubble",
+                label: showsLyrics ? "显示封面" : "显示歌词",
+                isActive: showsLyrics && !showsQueue
+            ) { onToggleLyrics() }
+
+            RoutePickerButton(diameter: 44, glyphSize: 17)
+                .frame(maxWidth: .infinity)
+
+            secondaryButton(
+                icon: "list.bullet",
+                label: showsQueue ? "关闭播放队列" : "显示播放队列",
+                isActive: showsQueue
+            ) { onToggleQueue() }
+        }
+    }
+
+    private func secondaryButton(
+        icon: String,
+        label: String,
+        isActive: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(isActive ? Theme.accent : .white.opacity(0.72))
+                .frame(width: 44, height: 44)
+                .background(.white.opacity(0.08), in: Circle())
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}
+
+private struct CompactQueueContent: View {
+    @EnvironmentObject private var player: PlayerService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 15) {
+            HStack(spacing: 10) {
+                modeButton(
+                    icon: "arrow.right",
+                    label: "顺序播放",
+                    isActive: !player.shuffleEnabled && player.repeatMode == .off,
+                    action: enableSequentialPlayback
+                )
+                modeButton(
+                    icon: "shuffle",
+                    label: player.shuffleEnabled ? "关闭随机播放" : "随机播放",
+                    isActive: player.shuffleEnabled,
+                    action: player.toggleShuffle
+                )
+                modeButton(
+                    icon: "repeat",
+                    label: "列表循环",
+                    isActive: player.repeatMode == .all
+                ) {
+                    player.repeatMode = player.repeatMode == .all ? .off : .all
+                }
+                modeButton(
+                    icon: "repeat.1",
+                    label: "单曲循环",
+                    isActive: player.repeatMode == .one
+                ) {
+                    player.repeatMode = player.repeatMode == .one ? .off : .one
+                }
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                Text("继续播放")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(.white)
+                Spacer()
+                Text("\(player.upcomingTracks.count) 首")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.46))
+            }
+
+            if player.upcomingTracks.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "list.bullet")
+                        .font(.system(size: 28, weight: .light))
+                    Text("播放队列是空的")
+                        .font(.subheadline.weight(.semibold))
+                }
+                .foregroundStyle(.white.opacity(0.5))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 4) {
+                        ForEach(
+                            Array(player.upcomingTracks.prefix(100).enumerated()),
+                            id: \.offset
+                        ) { _, track in
+                            CompactQueueRow(track: track)
+                        }
+                    }
+                }
+                .mask(
+                    LinearGradient(
+                        colors: [.black, .black, .clear],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+            }
+        }
+        .padding(.top, 6)
+    }
+
+    private func modeButton(
+        icon: String,
+        label: String,
+        isActive: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(isActive ? Color.black.opacity(0.76) : .white.opacity(0.76))
+                .frame(maxWidth: .infinity, minHeight: 42)
+                .background(
+                    isActive ? AnyShapeStyle(.white.opacity(0.66)) : AnyShapeStyle(.white.opacity(0.1)),
+                    in: Capsule()
+                )
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+
+    private func enableSequentialPlayback() {
+        if player.shuffleEnabled {
+            player.toggleShuffle()
+        }
+        player.repeatMode = .off
+    }
+}
+
+private struct CompactQueueRow: View {
+    let track: Track
+
+    @EnvironmentObject private var player: PlayerService
+
+    var body: some View {
+        Button {
+            player.jumpTo(track)
+        } label: {
+            HStack(spacing: 11) {
+                CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(120), animated: false)
+                    .frame(width: 46, height: 46)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(track.name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.9))
+                        .lineLimit(1)
+                    Text(track.artistNames)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.48))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                Text(Formatters.duration(track.duration))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.36))
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(track.name)，\(track.artistNames)")
+    }
+}
+
+private struct TranslucentSliderTrack: View {
+    let fraction: CGFloat
+    let isActive: Bool
+
+    private var clampedFraction: CGFloat {
+        min(max(fraction, 0), 1)
+    }
+
+    private var trackHeight: CGFloat {
+        isActive ? 10 : 6
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(.white.opacity(0.28))
+
+                Rectangle()
+                    .fill(.white.opacity(0.78))
+                    .frame(width: geo.size.width * clampedFraction)
+            }
+            .clipShape(Capsule())
+            .frame(height: trackHeight)
+            .frame(maxHeight: .infinity)
+        }
+        .animation(.spring(response: 0.24, dampingFraction: 0.82), value: isActive)
+    }
+}
+
+
+#endif
+
 
 // MARK: - Scrubber (white-on-dark variant)
 

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -26,11 +26,23 @@ struct TrackRow: View {
     @EnvironmentObject private var player: PlayerService
     @EnvironmentObject private var account: AccountStore
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @ScaledMetric(relativeTo: .body) private var compactArtworkSize: CGFloat = 48
+    @ScaledMetric(relativeTo: .body) private var compactRowHeight: CGFloat = 64
+    @ScaledMetric(relativeTo: .body) private var compactAlbumRowHeight: CGFloat = 50
     @State private var isHovering = false
     @State private var showAddToPlaylist = false
 
     private var isCurrent: Bool { player.currentTrack?.id == track.id }
     private var isPlayable: Bool { playability == .playable }
+    private var showsArtwork: Bool { style != .albumTrack }
+
+    private var hidesLeadingIndex: Bool {
+        #if os(iOS)
+        return isCompact && showsArtwork
+        #else
+        return false
+        #endif
+    }
 
     private var isCompact: Bool {
         #if os(iOS)
@@ -41,19 +53,19 @@ struct TrackRow: View {
     }
 
     var body: some View {
-        HStack(spacing: isCompact ? 10 : 12) {
-            leadingIndicator
+        HStack(spacing: 12) {
+            if !hidesLeadingIndex {
+                leadingIndicator
+            }
 
-            if style != .albumTrack {
-                CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(96), animated: false)
-                    .frame(width: isCompact ? 38 : 42, height: isCompact ? 38 : 42)
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
+            if showsArtwork {
+                artwork
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(track.name)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(isCompact ? .callout.weight(.medium) : .system(size: 13, weight: .medium))
                         .foregroundStyle(isCurrent ? Theme.accent : .primary)
                         .lineLimit(1)
                     if let subtitle = track.subtitle, !isCompact {
@@ -67,7 +79,7 @@ struct TrackRow: View {
                     }
                 }
                 Text(track.artistNames)
-                    .font(.system(size: 11.5))
+                    .font(isCompact ? .footnote : .system(size: 11.5))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -101,11 +113,11 @@ struct TrackRow: View {
 
             likeAndDuration
         }
-        .padding(.horizontal, isCompact ? 6 : 10)
-        .padding(.vertical, isCompact ? 4 : 5)
+        .padding(.horizontal, 10)
+        .padding(.vertical, isCompact ? 6 : 5)
         // Fixed row height keeps lazy-stack height estimation exact,
         // preventing scroll-offset jumps in long lists (#3).
-        .frame(height: style == .albumTrack ? (isCompact ? 44 : 46) : (isCompact ? 48 : 52))
+        .frame(height: rowHeight)
         .opacity(isPlayable ? 1 : 0.45)
         .background(
             RoundedRectangle(cornerRadius: Theme.Radius.standard, style: .continuous)
@@ -128,6 +140,38 @@ struct TrackRow: View {
         .sheet(isPresented: $showAddToPlaylist) {
             AddToPlaylistSheet(track: track)
         }
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if isCompact {
+            CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(160), animated: false)
+                .frame(width: compactArtworkSize, height: compactArtworkSize)
+                .overlay(alignment: .bottomTrailing) {
+                    if hidesLeadingIndex, isCurrent {
+                        PlayingIndicator(animating: player.isPlaying)
+                            .padding(5)
+                            .background(
+                                .ultraThinMaterial,
+                                in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            )
+                            .padding(4)
+                    }
+                }
+                .compositingGroup()
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
+        } else {
+            CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(96), animated: false)
+                .frame(width: 42, height: 42)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
+        }
+    }
+
+    private var rowHeight: CGFloat {
+        if style == .albumTrack {
+            return isCompact ? compactAlbumRowHeight : 46
+        }
+        return isCompact ? compactRowHeight : 52
     }
 
     @ViewBuilder

--- a/Sources/Kumone/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kumone/Resources/en.lproj/Localizable.strings
@@ -86,6 +86,8 @@
 
 /* Track list & context menu */
 "下一首播放" = "Play Next";
+"加入歌单…" = "Add to Playlist…";
+"更多操作" = "More Actions";
 "从「我喜欢」中移除" = "Remove from Liked Songs";
 "添加到「我喜欢」" = "Add to Liked Songs";
 "收藏到歌单…" = "Add to Playlist…";

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>


### PR DESCRIPTION
## 中文

### 概述

这个 PR 基于最新的 `upstream/main`，仅优化 iOS 播放体验，不改变 macOS 的界面和交互。

### 主要改动

- 新增 iPhone 沉浸式播放页
  - 紧凑的歌曲信息栏、同步歌词、封面视图和播放队列
  - 完整的播放、音量、AirPlay、收藏及更多操作
  - 支持下拉关闭，以及从迷你播放器进入播放页的空间转场
- 新增液态玻璃迷你播放器
  - iOS 26 使用系统 `tabViewBottomAccessory`
  - 列表向下滚动时，迷你播放器会随 Tab Bar 收纳为行内样式
  - iOS 16–25 继续使用上游现有的自定义玻璃 Tab Bar
- 优化 iPhone 歌曲列表
  - 增大封面与行高，重新整理标题、歌手和时长的层级
  - 紧凑布局隐藏序号，并在封面上显示当前播放状态
  - 保留动态字体适配与原有播放操作
- 保留最新上游更新
  - 保留 iOS 16 最低版本支持
  - 保留最新的日文歌词罗马音支持和 iOS 16–25 导航实现

### 界面预览

| 推荐页与液态玻璃播放器 | 沉浸式播放页 |
| --- | --- |
| <img src="https://raw.githubusercontent.com/miloquinn/kumone/pr-assets-immersive-player/IMG_8441.PNG" width="280" alt="推荐页与液态玻璃迷你播放器"> | <img src="https://raw.githubusercontent.com/miloquinn/kumone/pr-assets-immersive-player/IMG_8442.PNG" width="280" alt="沉浸式播放页与同步歌词"> |

| 展开状态与歌曲列表 | 滚动收纳后的行内播放器 |
| --- | --- |
| <img src="https://raw.githubusercontent.com/miloquinn/kumone/pr-assets-immersive-player/IMG_8443.PNG" width="280" alt="展开状态的迷你播放器和歌曲列表"> | <img src="https://raw.githubusercontent.com/miloquinn/kumone/pr-assets-immersive-player/IMG_8444.PNG" width="280" alt="滚动收纳后的行内迷你播放器"> |

### 测试

- [x] iOS Simulator Debug 构建通过
- [x] macOS `swift build` 通过
- [x] `Info.plist` 校验通过
- [x] `git diff --check` 通过
- [ ] 尚未运行真实设备自动化交互测试

---

## English

### Overview

This PR is based on the latest `upstream/main` and focuses exclusively on the iOS playback experience. It does not change the macOS UI or interaction behavior.

### Changes

- Added an immersive iPhone Now Playing view
  - Compact track header, synchronized lyrics, artwork view, and play queue
  - Full transport, volume, AirPlay, favorite, and additional track actions
  - Pull-to-dismiss interaction and a spatial transition from the mini player
- Added a Liquid Glass mini player
  - Uses the system `tabViewBottomAccessory` on iOS 26
  - Collapses into an inline layout together with the tab bar when scrolling down
  - Preserves the existing upstream custom glass tab bar on iOS 16–25
- Refined the iPhone track list
  - Larger artwork and row height with clearer title, artist, and duration hierarchy
  - Hides track numbers in compact layouts and shows playback state over the artwork
  - Preserves Dynamic Type support and existing playback actions
- Preserved the latest upstream changes
  - Keeps the iOS 16 minimum deployment target
  - Keeps the latest Japanese romaji lyrics support and iOS 16–25 navigation implementation

### Preview

The screenshots above show the home screen, immersive lyrics view, expanded mini player, refined track list, and the collapsed inline player after scrolling.

### Testing

- [x] iOS Simulator Debug build
- [x] macOS `swift build`
- [x] `Info.plist` validation
- [x] `git diff --check`
- [ ] Automated interaction testing on a physical device has not been run
