### PR TITLE
fix(macOS): reopen main window from Dock

### DIFF
--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct MainWindow: View {
+#if os(macOS)
+    @Environment(\.openWindow) private var openWindow
+#endif
     @EnvironmentObject private var player: PlayerService
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
@@ -50,6 +53,12 @@ struct MainWindow: View {
         .playerChrome(detailWidth: detailWidth)
         .environment(\.openLogin, { showLogin = true })
         .task {
+#if os(macOS)
+            // Keep this action in the app delegate: when the user closes the
+            // last WindowGroup window, there is no view left to receive a
+            // Dock reopen event directly.
+            AppDelegate.shared?.openMainWindow = { openWindow(id: "main") }
+#endif
             DesktopLyricsController.shared.sync(with: settings.showDesktopLyrics)
             await account.bootstrap()
         }

--- a/Sources/Kumone/KumoneApp.swift
+++ b/Sources/Kumone/KumoneApp.swift
@@ -84,9 +84,15 @@ public struct KumoneApp: App {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    static weak var shared: AppDelegate?
+
     private var keyMonitor: Any?
+    /// Installed by the SwiftUI main scene. Calling it recreates the scene
+    /// when its NSWindow was released after the user closed the last window.
+    var openMainWindow: (() -> Void)?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        Self.shared = self
         // Space toggles play/pause unless a text field is being edited.
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let noModifiers = event.modifierFlags
@@ -121,10 +127,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         false
     }
 
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag {
-            sender.windows.first { $0.identifier?.rawValue.contains("main") ?? false }?
-                .makeKeyAndOrderFront(nil)
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+        // `hasVisibleWindows` includes helper windows such as desktop lyrics.
+        // If the WindowGroup has already released its NSWindow, use the
+        // SwiftUI scene action below to create it again.
+        if let mainWindow = sender.windows.first(where: {
+            $0.styleMask.contains(.titled) && $0.canBecomeMain
+        }), !mainWindow.isVisible {
+            mainWindow.makeKeyAndOrderFront(nil)
+        } else if !sender.windows.contains(where: {
+            $0.isVisible && $0.styleMask.contains(.titled) && $0.canBecomeMain
+        }) {
+            openMainWindow?()
         }
         return true
     }


### PR DESCRIPTION
## Summary
- restore an existing hidden main window when the Dock icon is clicked
- reopen the SwiftUI `WindowGroup` when closing the last window released its underlying `NSWindow`
- do not treat helper windows such as desktop lyrics as the main window

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer Scripts/build-app.sh debug`
- `codesign --verify --deep --strict .build/app/Kumone.app`

Fixes #30.