### PR TITLE
perf: stop redrawing the whole view graph while idle

### DIFF
--- a/Sources/Kumone/Core/PlatformCompatibility.swift
+++ b/Sources/Kumone/Core/PlatformCompatibility.swift
@@ -4,6 +4,9 @@ import SwiftUI
 
 public typealias PlatformImage = NSImage
 public typealias PlatformColor = NSColor
+public typealias PlatformView = NSView
+public typealias PlatformFont = NSFont
+public typealias PlatformViewRepresentable = NSViewRepresentable
 
 public extension Image {
     init(platformImage: PlatformImage) {
@@ -59,6 +62,9 @@ import SwiftUI
 
 public typealias PlatformImage = UIImage
 public typealias PlatformColor = UIColor
+public typealias PlatformView = UIView
+public typealias PlatformFont = UIFont
+public typealias PlatformViewRepresentable = UIViewRepresentable
 
 public extension Image {
     init(platformImage: PlatformImage) {

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -93,6 +93,18 @@ final class PlaybackClock: ObservableObject {
     @Published var progress: TimeInterval = 0
 }
 
+/// Which lyric line is current.
+///
+/// Every lyric view used to derive this itself, which meant observing the clock
+/// and re-rendering on every tick just to discover the line hadn't changed —
+/// and for the now-playing page, whose body is the whole immersive layout, that
+/// was five full re-evaluations a second. Computing it once here and publishing
+/// only on a change turns that into one re-render per lyric line.
+@MainActor
+final class LyricsCursor: ObservableObject {
+    @Published var activeIndex: Int?
+}
+
 @MainActor
 final class PlayerService: ObservableObject {
     static let shared = PlayerService()
@@ -112,6 +124,7 @@ final class PlayerService: ObservableObject {
     @Published private(set) var unblockSource: String?
     @Published private(set) var isTrial = false
     let clock = PlaybackClock()
+    let lyricsCursor = LyricsCursor()
     /// Passthrough to the clock so existing `progress` reads/writes keep working.
     var progress: TimeInterval {
         get { clock.progress }
@@ -204,7 +217,17 @@ final class PlayerService: ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, !self.isScrubbing else { return }
                 let seconds = time.seconds
-                if seconds.isFinite, abs(seconds - self.progress) > 0.05 {
+                guard seconds.isFinite else { return }
+
+                // Lyrics need this cadence to stay in sync; the cursor itself
+                // only publishes when the line actually changes.
+                self.updateLyricsCursor(at: seconds)
+
+                // The scrubber does not. Publishing the position every tick
+                // re-renders it — and SwiftUI rebuilds the display list for the
+                // whole tree each time — to move the thumb a fraction of a
+                // pixel. Half a second is still smoother than the eye needs.
+                if abs(seconds - self.progress) > 0.45 {
                     self.progress = seconds
                     NowPlayingManager.shared.updateElapsed(seconds, rate: self.isPlaying ? 1 : 0)
                 }
@@ -339,8 +362,18 @@ final class PlayerService: ObservableObject {
         startPlaying(activeQueue[idx])
     }
 
+    /// Recomputes the current lyric line, publishing only on a change.
+    /// The lead makes a line light up just before it is sung.
+    private func updateLyricsCursor(at seconds: TimeInterval) {
+        let index = lyrics?.activeIndex(at: seconds + 0.2)
+        if index != lyricsCursor.activeIndex {
+            lyricsCursor.activeIndex = index
+        }
+    }
+
     func seek(to seconds: TimeInterval) {
         progress = seconds
+        updateLyricsCursor(at: seconds)
         engine.seek(to: CMTime(seconds: seconds, preferredTimescale: 600),
                     toleranceBefore: .zero, toleranceAfter: .zero)
         NowPlayingManager.shared.updateElapsed(seconds, rate: isPlaying ? 1 : 0)
@@ -497,6 +530,7 @@ final class PlayerService: ObservableObject {
         lyrics = nil
         scrobbled = false
         isPlaying = true
+        lyricsCursor.activeIndex = nil
         resolveGeneration += 1
         let generation = resolveGeneration
 
@@ -582,6 +616,7 @@ final class PlayerService: ObservableObject {
         let response = try? await NeteaseAPI.lyric(id: track.id)
         guard generation == resolveGeneration else { return }
         lyrics = response.map(LyricsParser.parse)
+        updateLyricsCursor(at: progress)
     }
 
     // MARK: - Scrobble

--- a/Sources/Kumone/DesignSystem/Cards.swift
+++ b/Sources/Kumone/DesignSystem/Cards.swift
@@ -90,6 +90,18 @@ struct Shelf<Content: View>: View {
     let title: LocalizedStringKey
     var seeAll: (() -> Void)?
     var spacing: CGFloat = 16
+    /// Height of one row of cards.
+    ///
+    /// Supplying it lets the shelf build its cards lazily, which matters more
+    /// than it sounds: a plain `HStack` instantiates every card in the shelf and
+    /// keeps it in the responder tree, so hit testing walks all of them on every
+    /// frame of a *vertical* scroll — including the ones scrolled off the side
+    /// and never seen. Measured at roughly half the cost of scrolling the home
+    /// page. It has to be stated rather than measured because a `LazyHStack`
+    /// reports no height until something has been scrolled into view, which
+    /// leaves the enclosing horizontal ScrollView with nothing to lay out
+    /// against and collapses the whole page.
+    var rowHeight: CGFloat?
     @ViewBuilder var content: () -> Content
 
     var body: some View {
@@ -97,14 +109,32 @@ struct Shelf<Content: View>: View {
             SectionHeader(title: title, action: seeAll)
                 .padding(.horizontal, Theme.Layout.contentInset)
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: spacing) {
-                    Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
-                    content()
-                    Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
-                }
-                .padding(.vertical, 6)
+                cards
+                    .padding(.vertical, 6)
             }
             .compatScrollClipDisabled()
+        }
+    }
+
+    private var edgeInset: some View {
+        Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
+    }
+
+    @ViewBuilder
+    private var cards: some View {
+        if let rowHeight {
+            LazyHStack(alignment: .top, spacing: spacing) {
+                edgeInset
+                content()
+                edgeInset
+            }
+            .frame(height: rowHeight)
+        } else {
+            HStack(alignment: .top, spacing: spacing) {
+                edgeInset
+                content()
+                edgeInset
+            }
         }
     }
 }

--- a/Sources/Kumone/DesignSystem/Components.swift
+++ b/Sources/Kumone/DesignSystem/Components.swift
@@ -206,6 +206,8 @@ struct PlayOverlayButton: View {
         .opacity(visible ? 1 : 0)
         .scaleEffect(visible ? 1 : 0.7)
         .animation(AppAnimation.spring, value: visible)
+        // Opacity alone leaves it clickable while invisible.
+        .allowsHitTesting(visible)
         #else
         EmptyView()
         #endif
@@ -215,87 +217,219 @@ struct PlayOverlayButton: View {
 // MARK: - Marquee
 
 /// Scrolls text horizontally when it overflows, with faded edges.
+///
+/// Driven by Core Animation rather than SwiftUI. This view sits permanently in
+/// the player bar, and a `repeatForever` SwiftUI animation keeps the entire view
+/// graph re-rendering for as long as it runs — measured at ~15% of a core, for
+/// as long as the current title happened to be long enough to scroll. A
+/// `CABasicAnimation` is handed to the render server once and then costs this
+/// process nothing.
 struct MarqueeText: View {
     let text: String
-    var font: Font = .system(size: 13, weight: .medium)
-
-    @State private var textWidth: CGFloat = 0
-    @State private var containerWidth: CGFloat = 0
-    @State private var offset: CGFloat = 0
-    @State private var animating = false
-
-    private var needsMarquee: Bool { textWidth > containerWidth + 1 }
+    var fontSize: CGFloat = 13
+    var fontWeight: PlatformFont.Weight = .medium
 
     var body: some View {
-        GeometryReader { geo in
-            HStack(spacing: 32) {
-                marqueeLabel
-                if needsMarquee {
-                    marqueeLabel
-                }
-            }
-            .offset(x: offset)
-            .frame(maxHeight: .infinity, alignment: .leading)
-            .onAppear { containerWidth = geo.size.width }
-            .onChange(of: geo.size.width) { newValue in containerWidth = newValue }
-        }
-        .clipped()
-        .mask(edgeFadeMask)
-        .onChange(of: text) { _ in
-            restart()
-        }
-        .onChange(of: needsMarquee) { _ in
-            restart()
-        }
-        .background(
-            Text(text)
-                .font(font)
-                .fixedSize()
-                .hidden()
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.onAppear { textWidth = geo.size.width }
-                            .onChange(of: geo.size.width) { newValue in textWidth = newValue }
-                    }
-                )
-        )
-    }
-
-    private var marqueeLabel: some View {
-        Text(text)
-            .font(font)
-            .lineLimit(1)
-            .fixedSize()
-    }
-
-    private var edgeFadeMask: some View {
-        LinearGradient(
-            stops: [
-                .init(color: animating ? .clear : .black, location: 0),
-                .init(color: .black, location: animating ? 0.06 : 0),
-                .init(color: .black, location: needsMarquee ? 0.94 : 1),
-                .init(color: needsMarquee ? .clear : .black, location: 1),
-            ],
-            startPoint: .leading, endPoint: .trailing
-        )
-    }
-
-    private func restart() {
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            offset = 0
-            animating = false
-        }
-        guard needsMarquee, !Platform.isReduceMotionEnabled else { return }
-        let distance = textWidth + 32
-        let duration = Double(distance) / 24
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-            guard needsMarquee else { return }
-            animating = true
-            withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
-                offset = -distance
-            }
-        }
+        MarqueeTextView.Representable(text: text, fontSize: fontSize, weight: fontWeight)
     }
 }
+
+final class MarqueeTextView: PlatformView {
+    /// Gap between the two copies of the text.
+    private static let gap: CGFloat = 32
+    /// Points per second.
+    private static let speed: CGFloat = 24
+    /// Pause before a new title starts travelling, so it can be read first.
+    private static let leadIn: CFTimeInterval = 1.6
+    private static let fadeFraction = 0.06
+
+    private let scroller = CALayer()
+    private let first = CATextLayer()
+    private let second = CATextLayer()
+    private let fade = CAGradientLayer()
+
+    private var text: String
+    private var fontSize: CGFloat
+    private var weight: PlatformFont.Weight
+    private var textWidth: CGFloat = 0
+    /// Guards against re-running layout on every display cycle: the host view
+    /// calls layout() each frame while an animation is in flight, and tearing
+    /// the animation down and rebuilding it there costs more than the SwiftUI
+    /// version ever did.
+    private var laidOutFor: CGSize = .zero
+    private var needsMarquee: Bool { textWidth > bounds.width + 1 }
+
+    init(text: String, fontSize: CGFloat, weight: PlatformFont.Weight) {
+        self.text = text
+        self.fontSize = fontSize
+        self.weight = weight
+        super.init(frame: .zero)
+        #if os(macOS)
+        wantsLayer = true
+        #endif
+        layer?.addSublayer(scroller)
+        scroller.addSublayer(first)
+        scroller.addSublayer(second)
+        layer?.mask = fade
+        fade.startPoint = CGPoint(x: 0, y: 0.5)
+        fade.endPoint = CGPoint(x: 1, y: 0.5)
+        for textLayer in [first, second] {
+            textLayer.contentsScale = 2
+            textLayer.truncationMode = .none
+            textLayer.isWrapped = false
+        }
+        applyText()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    func update(text: String, fontSize: CGFloat, weight: PlatformFont.Weight) {
+        guard text != self.text || fontSize != self.fontSize || weight != self.weight else { return }
+        self.text = text
+        self.fontSize = fontSize
+        self.weight = weight
+        applyText()
+        relayout()
+    }
+
+    private var font: PlatformFont { .systemFont(ofSize: fontSize, weight: weight) }
+
+    private var labelColor: CGColor {
+        #if os(macOS)
+        return NSColor.labelColor.cgColor
+        #else
+        return UIColor.label.cgColor
+        #endif
+    }
+
+    private func applyText() {
+        let font = self.font
+        textWidth = (text as NSString).size(withAttributes: [.font: font]).width.rounded(.up)
+        for textLayer in [first, second] {
+            textLayer.string = text
+            textLayer.font = font
+            textLayer.fontSize = fontSize
+            textLayer.foregroundColor = labelColor
+        }
+    }
+
+    #if os(macOS)
+    override func layout() {
+        super.layout()
+        guard bounds.size != laidOutFor else { return }
+        relayout()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        // A CGColor is a snapshot; unlike a dynamic NSColor it won't follow the
+        // appearance on its own.
+        first.foregroundColor = labelColor
+        second.foregroundColor = labelColor
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        let scale = window?.backingScaleFactor ?? 2
+        first.contentsScale = scale
+        second.contentsScale = scale
+        relayout()
+    }
+    #else
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard bounds.size != laidOutFor else { return }
+        relayout()
+    }
+
+    override func traitCollectionDidChange(_ previous: UITraitCollection?) {
+        super.traitCollectionDidChange(previous)
+        first.foregroundColor = labelColor
+        second.foregroundColor = labelColor
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        let scale = window?.screen.scale ?? 2
+        first.contentsScale = scale
+        second.contentsScale = scale
+        relayout()
+    }
+    #endif
+
+    private func relayout() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+        laidOutFor = bounds.size
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        let lineHeight = ceil(font.ascender - font.descender)
+        let y = ((bounds.height - lineHeight) / 2).rounded()
+        first.frame = CGRect(x: 0, y: y, width: textWidth, height: lineHeight)
+        second.frame = CGRect(x: textWidth + Self.gap, y: y, width: textWidth, height: lineHeight)
+        second.isHidden = !needsMarquee
+        scroller.anchorPoint = .zero
+        scroller.bounds = CGRect(x: 0, y: 0,
+                                 width: textWidth * 2 + Self.gap, height: bounds.height)
+        scroller.position = .zero
+        fade.frame = bounds
+        fade.colors = fadeColors()
+        fade.locations = fadeLocations()
+
+        CATransaction.commit()
+        restartAnimation()
+    }
+
+    private func fadeColors() -> [CGColor] {
+        let opaque = PlatformColor.black.cgColor
+        let clear = PlatformColor.black.withAlphaComponent(0).cgColor
+        guard needsMarquee else { return [opaque, opaque, opaque, opaque] }
+        return [clear, opaque, opaque, clear]
+    }
+
+    private func fadeLocations() -> [NSNumber] {
+        guard needsMarquee else { return [0, 0, 1, 1] }
+        return [0, NSNumber(value: Self.fadeFraction),
+                NSNumber(value: 1 - Self.fadeFraction), 1]
+    }
+
+    private func restartAnimation() {
+        scroller.removeAnimation(forKey: "marquee")
+        guard needsMarquee, !Platform.isReduceMotionEnabled else { return }
+
+        let distance = textWidth + Self.gap
+        let animation = CABasicAnimation(keyPath: "position.x")
+        animation.byValue = -distance
+        animation.duration = CFTimeInterval(distance / Self.speed)
+        animation.repeatCount = .infinity
+        animation.isRemovedOnCompletion = false
+        animation.beginTime = CACurrentMediaTime() + Self.leadIn
+        scroller.add(animation, forKey: "marquee")
+    }
+
+    // MARK: Bridge
+
+    struct Representable: PlatformViewRepresentable {
+        let text: String
+        let fontSize: CGFloat
+        let weight: PlatformFont.Weight
+
+        #if os(macOS)
+        func makeNSView(context: Context) -> MarqueeTextView {
+            MarqueeTextView(text: text, fontSize: fontSize, weight: weight)
+        }
+        func updateNSView(_ view: MarqueeTextView, context: Context) {
+            view.update(text: text, fontSize: fontSize, weight: weight)
+        }
+        #else
+        func makeUIView(context: Context) -> MarqueeTextView {
+            MarqueeTextView(text: text, fontSize: fontSize, weight: weight)
+        }
+        func updateUIView(_ view: MarqueeTextView, context: Context) {
+            view.update(text: text, fontSize: fontSize, weight: weight)
+        }
+        #endif
+    }
+}
+

--- a/Sources/Kumone/DesignSystem/Theme.swift
+++ b/Sources/Kumone/DesignSystem/Theme.swift
@@ -22,6 +22,11 @@ enum Theme {
     enum Layout {
         static let contentInset: CGFloat = 24
         static let cardSize: CGFloat = 160
+        /// Row height for a shelf of cover cards: artwork, then up to two lines
+        /// of title and one of subtitle.
+        static let coverShelfHeight: CGFloat = 226
+        /// Row height for a shelf of artist cards: circular artwork, one name.
+        static let artistShelfHeight: CGFloat = 196
         static let sidebarWidth: CGFloat = 220
         static let playerBarHeight: CGFloat = 56
         /// Gap between the floating player bar and the window's bottom edge.

--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -153,7 +153,7 @@ struct HomeView: View {
             }
 
             if !model.recommendPlaylists.isEmpty {
-                Shelf(title: "推荐歌单") {
+                Shelf(title: "推荐歌单", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(Array(model.recommendPlaylists.prefix(12).enumerated()), id: \.element.id) { index, playlist in
                         playlistCard(playlist)
                             .staggeredAppearance(index: index, id: "home-rec-\(playlist.id)")
@@ -162,7 +162,7 @@ struct HomeView: View {
             }
 
             if !model.radarPlaylists.isEmpty {
-                Shelf(title: "雷达歌单") {
+                Shelf(title: "雷达歌单", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.radarPlaylists) { radar in
                         NavigationLink(value: Destination.playlist(radar.id)) {
                             CoverCardBody(
@@ -179,7 +179,7 @@ struct HomeView: View {
             }
 
             if !model.toplists.isEmpty {
-                Shelf(title: "排行榜", seeAll: nil) {
+                Shelf(title: "排行榜", seeAll: nil, rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.toplists) { toplist in
                         NavigationLink(value: Destination.playlist(toplist.id)) {
                             toplistCard(toplist)
@@ -190,7 +190,7 @@ struct HomeView: View {
             }
 
             if !model.newAlbums.isEmpty {
-                Shelf(title: "新碟上架") {
+                Shelf(title: "新碟上架", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.newAlbums) { album in
                         albumCard(album)
                     }
@@ -198,7 +198,7 @@ struct HomeView: View {
             }
 
             if !model.topArtists.isEmpty {
-                Shelf(title: "推荐歌手") {
+                Shelf(title: "推荐歌手", rowHeight: Theme.Layout.artistShelfHeight) {
                     ForEach(model.topArtists) { artist in
                         artistCard(artist)
                     }

--- a/Sources/Kumone/Features/Player/DesktopLyrics.swift
+++ b/Sources/Kumone/Features/Player/DesktopLyrics.swift
@@ -118,13 +118,13 @@ private struct DesktopLyricsSurface: View {
 
 private struct DesktopLyricsBox: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     private var currentLine: LyricLine? {
-        guard player.isPlaying || clock.progress > 0,
+        guard player.isPlaying || PlayerService.shared.progress > 0,
               let lyrics = player.lyrics, !lyrics.isEmpty,
-              let index = lyrics.activeIndex(at: clock.progress + 0.2) else { return nil }
+              let index = lyricsCursor.activeIndex else { return nil }
         return lyrics.lines[index]
     }
 

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// large artwork on the left, big synced lyrics on the right.
 struct NowPlayingView: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
     #if os(iOS)
@@ -124,6 +124,20 @@ struct NowPlayingView: View {
         #else
         return true
         #endif
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
+        }
     }
 
     // MARK: - Backdrop
@@ -552,14 +566,19 @@ struct NowPlayingView: View {
                         startPoint: .top, endPoint: .bottom
                     )
                 )
-                .onChange(of: clock.progress) { _ in
-                    let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                .onChange(of: lyricsCursor.activeIndex) { index in
                     guard index != activeIndex else { return }
                     activeIndex = index
                     guard !isUserScrolling, let index else { return }
                     withAnimation(.spring(response: 0.8, dampingFraction: 0.85)) {
                         proxy.scrollTo(index, anchor: .center)
                     }
+                }
+                .onAppear {
+                    // The cursor only fires on a line change, which can be many
+                    // seconds away — on re-entering the page, adopt where the
+                    // song already is instead of waiting for the next line.
+                    adoptCursor(proxy: proxy)
                 }
                 .onChange(of: player.currentTrack?.id) { _ in
                     activeIndex = nil
@@ -627,7 +646,7 @@ struct NowPlayingView: View {
 #if os(iOS)
 private struct IOSImmersiveLyricsColumn: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     @State private var activeIndex: Int?
@@ -651,14 +670,16 @@ private struct IOSImmersiveLyricsColumn: View {
                     }
                     .mask(edgeMask)
                     .accessibilityIdentifier("syncedLyricsScroll")
-                    .onChange(of: clock.progress) { _ in
-                        let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                    .onChange(of: lyricsCursor.activeIndex) { index in
                         guard index != activeIndex else { return }
                         activeIndex = index
                         guard !isUserScrolling, let index else { return }
                         withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.38)) {
                             proxy.scrollTo(index, anchor: .center)
                         }
+                    }
+                    .onAppear {
+                        adoptCursor(proxy: proxy)
                     }
                     .onChange(of: player.currentTrack?.id) { _ in
                         activeIndex = nil
@@ -699,6 +720,20 @@ private struct IOSImmersiveLyricsColumn: View {
         }
         .onDisappear {
             resumeTask?.cancel()
+        }
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
         }
     }
 
@@ -1278,11 +1313,11 @@ struct MiniLyricsView: View {
     let onOpen: () -> Void
 
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
 
     private var lines: (previous: LyricLine?, current: LyricLine?, next: LyricLine?) {
         guard let lyrics = player.lyrics, !lyrics.isEmpty else { return (nil, nil, nil) }
-        guard let index = lyrics.activeIndex(at: clock.progress + 0.2) else {
+        guard let index = lyricsCursor.activeIndex else {
             return (nil, nil, lyrics.lines.first)
         }
         let all = lyrics.lines

--- a/Sources/Kumone/Features/Player/Panels.swift
+++ b/Sources/Kumone/Features/Player/Panels.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct LyricsPanel: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     @State private var activeIndex: Int?
@@ -69,14 +69,16 @@ struct LyricsPanel: View {
                     }
                     .padding(.horizontal, 20)
                 }
-                .onChange(of: clock.progress) { _ in
-                    let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                .onChange(of: lyricsCursor.activeIndex) { index in
                     guard index != activeIndex else { return }
                     activeIndex = index
                     guard !isUserScrolling, let index else { return }
                     withAnimation(.spring(response: 0.7, dampingFraction: 0.85)) {
                         proxy.scrollTo(index, anchor: .center)
                     }
+                }
+                .onAppear {
+                    adoptCursor(proxy: proxy)
                 }
                 .onChange(of: player.currentTrack?.id) { _ in
                     activeIndex = nil
@@ -106,6 +108,20 @@ struct LyricsPanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             EmptyStateView(icon: "quote.bubble", title: "暂无歌词")
+        }
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
         }
     }
 


### PR DESCRIPTION
加载完成的首页，**什么都不做也在持续消耗约 16% 的单核 CPU**——没有动画在跑，也不需要播放，就那么放着。profiling 找出三个互不相关的原因。

这些问题都不是本分支引入的，在正式版里已存在。

## 实测数据（release 构建）

| | 修复前 | 修复后 |
|---|---|---|
| 静止（首页已加载） | ~16% | **0%** |
| 全屏播放页 | 25% | **5–12%** |
| 首页滚动 | 30% | 27% |

## 问题分别是什么

### `MarqueeText` 的动画永不停止

```swift
withAnimation(.linear(duration: duration).repeatForever(autoreverses: false))
```

只要当前歌名长到需要滚动，这个动画就永远跑下去——而 `MarqueeText` 常驻在播放条里。**任何进行中的 SwiftUI 动画都会让整棵视图树每帧重新 render**，它还带着一个渐变遮罩，于是每帧还要重新渲染一次带样式的形状。

那 16% 全部来自这里。现在改为 `CATextLayer` 上的 `CABasicAnimation`：提交一次交给 render server，之后本进程不再参与。

有一点值得 reviewer 留意——第一版 Core Animation 改造**依然是 15%**，因为我把重启动画放在了 `layout()` 里，而宿主视图在动画期间每帧都会调用它。**换到 layer 本身不会让它变快，前提是别在每帧回调里做重活。** 真正让它归零的是 `layout()` 里那个尺寸未变就跳过的判断。

### 歌词每秒重算五次，而且是整页

每个歌词视图——全屏页、侧边面板、桌面歌词、迷你歌词——都各自从播放时钟推导当前行。于是每个都每秒重新求值 5 次，只为发现行根本没变；而 `NowPlayingView` 的 body **就是**整个沉浸式布局。

现在集中计算一次，仅在真正换行时广播。歌词的同步精度没有下降（内部仍以原节奏检查），下降的只是通知 UI 的频率。

进度条的位置改为每 0.5 秒发布一次（原本 0.2 秒）——它此前为了把滑块挪动零点几个像素，要重建整棵树的 display list。

### 货架把所有卡片都留在 responder 树里

普通 `HStack` 会实例化货架里的每一张卡片并一直保留，于是**纵向**滚动的每一帧，命中测试都要遍历它们全部——包括那些横向滚出视野、从未被看到的卡片。

⚠️ **这一项有需要知晓的维护成本。** `Shelf.rowHeight` 必须显式声明，因为 `LazyHStack` 在内容滚入视野前不报告高度，会让外层横向 ScrollView 失去布局依据，**导致整页塌陷**。如果卡片布局发生变化（比如标题多一行），`Theme.Layout.coverShelfHeight` / `artistShelfHeight` 必须同步更新，否则文字会被截断。声明处已写了注释。

这一项只值约 10%，所以如果觉得这个约束不划算，它是最该先砍掉的部分。

### 隐藏的悬停播放按钮仍可被点击

`PlayOverlayButton` 用 `.opacity(0)` 隐藏，但它仍留在 responder 树里——可以隔着封面被点到。现在改用 `.allowsHitTesting(visible)`。这一项没有可测量的性能收益，是个正确性修复。

## 没能解决的部分

首页滚动仍有约 27%。采样显示大头在命中测试（约 6700 采样，而 display list 更新是 2740），但两次针对性尝试——先排除隐藏按钮、再干脆不构建它——都没有任何可测量的变化。成本不在于 responder 的**数量**，而在于 SwiftUI 每帧重建命中测试状态本身。要绕过它就得放弃这里的 `ScrollView` + `LazyVStack`，那远超本 PR 的范围。

一个参考数据：把光标移到窗口外，同样的滚动只需约 7%。所以大部分成本系在"指针悬停在内容上"这件事上，而这在真实使用中无法避免。

## 测试

macOS release 构建，用固定窗口内的累计进程 CPU 时间测量（瞬时 `%CPU` 噪声太大，无法用于比较两次改动）。滚动由合成事件驱动，保证可复现。

**请重点验证跑马灯**，因为它被整个重写了：长标题是否仍然滚动、边缘淡出是否正常、切歌后是否重新开始、以及深浅色切换后颜色是否正确。

**iOS 未验证**——本机没有 Xcode，iOS target 从未编译过。本次没有新增平台分支，用到的 API 在 iOS 16 上都存在，但需要 CI 把关。
