### PR TITLE
feat(player): drive the playing indicator from the audio

### DIFF
--- a/Sources/Kumone/Core/PlatformCompatibility.swift
+++ b/Sources/Kumone/Core/PlatformCompatibility.swift
@@ -4,6 +4,9 @@ import SwiftUI
 
 public typealias PlatformImage = NSImage
 public typealias PlatformColor = NSColor
+public typealias PlatformView = NSView
+public typealias PlatformFont = NSFont
+public typealias PlatformViewRepresentable = NSViewRepresentable
 
 public extension Image {
     init(platformImage: PlatformImage) {
@@ -59,6 +62,9 @@ import SwiftUI
 
 public typealias PlatformImage = UIImage
 public typealias PlatformColor = UIColor
+public typealias PlatformView = UIView
+public typealias PlatformFont = UIFont
+public typealias PlatformViewRepresentable = UIViewRepresentable
 
 public extension Image {
     init(platformImage: PlatformImage) {

--- a/Sources/Kumone/Core/Player/AudioSpectrum.swift
+++ b/Sources/Kumone/Core/Player/AudioSpectrum.swift
@@ -11,9 +11,9 @@ import MediaToolbox
 /// preallocated, lock-free and allocation-free.
 ///
 /// Not every track can be tapped — an audio mix needs a resolved `AVAssetTrack`,
-/// and a source server that refuses byte-range requests never produces one. That
-/// is why `isLive` exists: callers fall back to a decorative animation when the
-/// real thing is unavailable.
+/// and a source server that refuses byte-range requests never produces one. See
+/// `tapState`, which callers use to decide between real levels, holding still,
+/// and the decorative fallback.
 @MainActor
 final class AudioSpectrum {
     static let shared = AudioSpectrum()
@@ -22,11 +22,39 @@ final class AudioSpectrum {
     /// too, so it stays outside the actor's isolation.
     nonisolated static let bandCount = 4
 
-    private let store = SpectrumStore()
+    /// Replaced for each new item rather than cleared.
+    ///
+    /// The outgoing track's tap keeps running until its player item is actually
+    /// swapped out, so clearing the store in place doesn't work: the old tap
+    /// simply writes the old track's levels straight back, and the bars show the
+    /// previous song for a moment as the new one starts. Handing the new item a
+    /// fresh store leaves the old tap writing to one nobody reads, which it
+    /// keeps alive on its own until it is finalized.
+    private var store = SpectrumStore()
     private init() {}
 
     /// True while the tap is actually delivering samples for the current track.
     var isLive: Bool { store.isLive }
+
+    /// What is known about the current track's tap.
+    ///
+    /// Three states rather than a flag, because there is a stretch after the
+    /// user hits play where the answer isn't known yet: the track's URL is still
+    /// being resolved. Treating that as "untappable" flashes the decorative
+    /// animation for a moment right as a song starts, and treating it as
+    /// "tapped" would freeze the previous track's last frame under it.
+    enum TapState {
+        /// Nothing playing.
+        case idle
+        /// Resolving the source; it isn't known yet whether it can be tapped.
+        case preparing
+        /// A tap is attached. `isLive` says whether samples have arrived yet.
+        case tapped
+        /// This source can't be tapped — the decorative fallback belongs here.
+        case untappable
+    }
+
+    private(set) var tapState: TapState = .idle
 
     /// Latest level for one band, already smoothed and normalized to `0...1`.
     /// A single pointer read — cheap enough to call per bar, per frame.
@@ -45,11 +73,31 @@ final class AudioSpectrum {
         params.audioTapProcessor = tap
         let mix = AVMutableAudioMix()
         mix.inputParameters = [params]
+        tapState = .tapped
         return mix
     }
 
-    /// Silences the bands — call when playback stops or the track changes so a
-    /// frozen last frame doesn't linger under the UI.
+    /// Call as soon as a track is chosen — before its URL is resolved — so the
+    /// bars hold still instead of falling back while the answer is unknown.
+    func beginPreparing() {
+        tapState = .preparing
+        store = SpectrumStore()
+    }
+
+    /// Call once it's settled that this source can't be tapped.
+    func markUntappable() {
+        tapState = .untappable
+        store.reset()
+    }
+
+    /// Call when playback stops entirely.
+    func markIdle() {
+        tapState = .idle
+        store.reset()
+    }
+
+    /// Silences the bands without forgetting that the current item is tapped —
+    /// pausing shouldn't make a tapped track look untappable when it resumes.
     func reset() {
         store.reset()
     }

--- a/Sources/Kumone/Core/Player/AudioSpectrum.swift
+++ b/Sources/Kumone/Core/Player/AudioSpectrum.swift
@@ -1,0 +1,397 @@
+import Accelerate
+import AVFoundation
+import Foundation
+import MediaToolbox
+
+/// Real-time band levels pulled out of the playing audio.
+///
+/// `AVPlayer` exposes no metering, so we splice an `MTAudioProcessingTap` into
+/// the player item's audio mix and run a small FFT on the PCM it hands us. The
+/// tap runs on a real-time audio thread: everything it touches below is
+/// preallocated, lock-free and allocation-free.
+///
+/// Not every track can be tapped — an audio mix needs a resolved `AVAssetTrack`,
+/// and a source server that refuses byte-range requests never produces one. That
+/// is why `isLive` exists: callers fall back to a decorative animation when the
+/// real thing is unavailable.
+@MainActor
+final class AudioSpectrum {
+    static let shared = AudioSpectrum()
+
+    /// Number of frequency bands published to the UI. Read from the audio thread
+    /// too, so it stays outside the actor's isolation.
+    nonisolated static let bandCount = 4
+
+    private let store = SpectrumStore()
+    private init() {}
+
+    /// True while the tap is actually delivering samples for the current track.
+    var isLive: Bool { store.isLive }
+
+    /// Latest level for one band, already smoothed and normalized to `0...1`.
+    /// A single pointer read — cheap enough to call per bar, per frame.
+    func level(at index: Int) -> Float {
+        store.level(at: index)
+    }
+
+
+    /// Builds the audio mix that feeds this analyzer.
+    ///
+    /// - Returns: `nil` when the track can't be tapped, in which case the caller
+    ///   should play the item as-is and let the UI fall back.
+    func makeAudioMix(for track: AVAssetTrack) -> AVAudioMix? {
+        guard let tap = store.makeTap() else { return nil }
+        let params = AVMutableAudioMixInputParameters(track: track)
+        params.audioTapProcessor = tap
+        let mix = AVMutableAudioMix()
+        mix.inputParameters = [params]
+        return mix
+    }
+
+    /// Silences the bands — call when playback stops or the track changes so a
+    /// frozen last frame doesn't linger under the UI.
+    func reset() {
+        store.reset()
+    }
+}
+
+// MARK: - Lock-free store shared with the audio thread
+
+/// Backing storage for the tap. Held by `AudioSpectrum` on the main actor and by
+/// the tap's `clientInfo` on the audio thread; every field it exposes is a plain
+/// `Float` slot, so a torn read costs at most one slightly stale bar.
+private final class SpectrumStore: @unchecked Sendable {
+    /// FFT window. 512 samples ≈ 12ms at 44.1kHz — fast enough to feel reactive,
+    /// long enough to resolve bass.
+    private static let fftSize = 512
+    private static let log2n = vDSP_Length(9)   // 2^9 == 512
+    private static let binCount = fftSize / 2
+
+    /// Published band levels, written by the audio thread, read by the UI.
+    private let levels: UnsafeMutablePointer<Float>
+    /// Whether the tap has produced audio recently.
+    private let liveFlag: UnsafeMutablePointer<Int32>
+
+    /// Scratch buffers — preallocated because the audio thread must not malloc.
+    private let window: UnsafeMutablePointer<Float>
+    private let mono: UnsafeMutablePointer<Float>
+    private let ring: UnsafeMutablePointer<Float>
+    private var ringFill = 0
+    private let realp: UnsafeMutablePointer<Float>
+    private let imagp: UnsafeMutablePointer<Float>
+    private let magnitudes: UnsafeMutablePointer<Float>
+    private let fftSetup: FFTSetup?
+
+    /// Source format, learned in the tap's prepare callback.
+    private var sampleRate: Double = 44_100
+    private var channelCount = 2
+    private var isInterleaved = true
+
+    /// Band definitions resolved to bin indices for the current sample rate.
+    private let binLo: UnsafeMutablePointer<Int32>
+    private let binHi: UnsafeMutablePointer<Int32>
+    /// Current window edges in dB, tracking the level this band is producing.
+    private let windowHiDB: UnsafeMutablePointer<Float>
+    private let windowLoDB: UnsafeMutablePointer<Float>
+
+    init() {
+        let n = Self.fftSize
+        levels = .allocate(capacity: AudioSpectrum.bandCount)
+        levels.initialize(repeating: 0, count: AudioSpectrum.bandCount)
+        liveFlag = .allocate(capacity: 1)
+        liveFlag.initialize(to: 0)
+        window = .allocate(capacity: n)
+        mono = .allocate(capacity: n)
+        ring = .allocate(capacity: n)
+        ring.initialize(repeating: 0, count: n)
+        realp = .allocate(capacity: Self.binCount)
+        imagp = .allocate(capacity: Self.binCount)
+        magnitudes = .allocate(capacity: Self.binCount)
+        binLo = .allocate(capacity: AudioSpectrum.bandCount)
+        binHi = .allocate(capacity: AudioSpectrum.bandCount)
+        windowHiDB = .allocate(capacity: AudioSpectrum.bandCount)
+        windowLoDB = .allocate(capacity: AudioSpectrum.bandCount)
+        fftSetup = vDSP_create_fftsetup(Self.log2n, FFTRadix(kFFTRadix2))
+        vDSP_hann_window(window, vDSP_Length(n), Int32(vDSP_HANN_NORM))
+        // Seeded for the common rate; `adopt(format:)` corrects it if the source
+        // turns out to be 48kHz or Hi-Res.
+        for i in 0..<AudioSpectrum.bandCount {
+            let band = Self.bandEdges[i]
+            let binWidth = Float(44_100) / Float(n)
+            binLo[i] = Int32(max(1, Int(band.low / binWidth)))
+            binHi[i] = Int32(min(Self.binCount - 1, Int(band.high / binWidth)))
+            windowHiDB[i] = band.ceilingDB
+            windowLoDB[i] = band.floorDB
+        }
+    }
+
+    deinit {
+        levels.deallocate()
+        liveFlag.deallocate()
+        window.deallocate()
+        mono.deallocate()
+        ring.deallocate()
+        realp.deallocate()
+        imagp.deallocate()
+        magnitudes.deallocate()
+        binLo.deallocate()
+        binHi.deallocate()
+        windowHiDB.deallocate()
+        windowLoDB.deallocate()
+        if let fftSetup { vDSP_destroy_fftsetup(fftSetup) }
+    }
+
+    var isLive: Bool { liveFlag.pointee != 0 }
+
+    func level(at index: Int) -> Float {
+        guard index >= 0, index < AudioSpectrum.bandCount else { return 0 }
+        return levels[index]
+    }
+
+    func reset() {
+        for i in 0..<AudioSpectrum.bandCount {
+            levels[i] = 0
+            // Start each track from the calibrated window rather than inheriting
+            // the last one's loudness.
+            let band = Self.bandEdges[i]
+            windowHiDB[i] = band.ceilingDB
+            windowLoDB[i] = band.floorDB
+        }
+        ringFill = 0
+        liveFlag.pointee = 0
+    }
+
+    // MARK: Tap plumbing
+
+    func makeTap() -> MTAudioProcessingTap? {
+        // The tap holds an unmanaged +1 reference; `finalize` gives it back.
+        let retained = Unmanaged.passRetained(self)
+        var callbacks = MTAudioProcessingTapCallbacks(
+            version: kMTAudioProcessingTapCallbacksVersion_0,
+            clientInfo: UnsafeMutableRawPointer(retained.toOpaque()),
+            init: { _, clientInfo, storageOut in storageOut.pointee = clientInfo },
+            finalize: { tap in
+                Unmanaged<SpectrumStore>
+                    .fromOpaque(MTAudioProcessingTapGetStorage(tap)).release()
+            },
+            prepare: { tap, _, format in
+                let store = Unmanaged<SpectrumStore>
+                    .fromOpaque(MTAudioProcessingTapGetStorage(tap)).takeUnretainedValue()
+                store.adopt(format: format.pointee)
+            },
+            // Deliberately no unprepare: on a track change the outgoing tap tears
+            // down after the incoming one is already feeding us, so clearing here
+            // would blank the new track's first frames. `PlayerService` resets
+            // explicitly at the points where silence is actually correct.
+            unprepare: nil,
+            process: { tap, numberFrames, _, bufferListInOut, numberFramesOut, flagsOut in
+                let status = MTAudioProcessingTapGetSourceAudio(
+                    tap, numberFrames, bufferListInOut, flagsOut, nil, numberFramesOut)
+                guard status == noErr else { return }
+                let store = Unmanaged<SpectrumStore>
+                    .fromOpaque(MTAudioProcessingTapGetStorage(tap)).takeUnretainedValue()
+                store.process(bufferListInOut, frames: Int(numberFramesOut.pointee))
+            }
+        )
+
+        var tap: MTAudioProcessingTap?
+        let err = MTAudioProcessingTapCreate(
+            kCFAllocatorDefault, &callbacks,
+            kMTAudioProcessingTapCreationFlag_PostEffects, &tap)
+        guard err == noErr, let tap else {
+            // `finalize:` will never run, so hand the retain back by hand.
+            retained.release()
+            return nil
+        }
+        return tap
+    }
+
+    private func adopt(format: AudioStreamBasicDescription) {
+        sampleRate = format.mSampleRate > 0 ? format.mSampleRate : 44_100
+        channelCount = max(1, Int(format.mChannelsPerFrame))
+        isInterleaved = (format.mFormatFlags & kAudioFormatFlagIsNonInterleaved) == 0
+
+        // Resolve each band to bin indices once, here, so the process callback
+        // touches nothing but plain buffers — iterating a Swift array of tuples
+        // on a real-time thread risks retain traffic and lazy-init locks.
+        let binWidth = Float(sampleRate) / Float(Self.fftSize)
+        for i in 0..<AudioSpectrum.bandCount {
+            let band = Self.bandEdges[i]
+            binLo[i] = Int32(max(1, Int(band.low / binWidth)))
+            binHi[i] = Int32(min(Self.binCount - 1, Int(band.high / binWidth)))
+            windowHiDB[i] = band.ceilingDB
+            windowLoDB[i] = band.floorDB
+        }
+    }
+
+    // MARK: Audio-thread analysis
+
+    /// Frequency bands, each with its own dB window.
+    ///
+    /// Music falls off steeply with frequency — measured across tracks, presence
+    /// sits some 30dB under bass — so one shared window would peg the low bars and
+    /// leave the high ones flat on the floor. The windows below were calibrated
+    /// from real material so every bar spends its time in the visible middle.
+    private static let bandEdges: [(low: Float, high: Float, floorDB: Float, ceilingDB: Float)] = [
+        (60, 250, -44, -20),
+        (250, 800, -46, -26),
+        (800, 2_500, -62, -36),
+        (2_500, 8_000, -72, -50),
+    ]
+
+    /// Envelope time constants in seconds: rise fast so transients register,
+    /// fall slowly so the bars read as motion rather than flicker. A slow release
+    /// smears beats together and the bars stop reading as movement at all.
+    private static let attackSeconds: Float = 0.03
+    private static let releaseSeconds: Float = 0.16
+
+    /// Each band's window tracks both edges of the level it actually sees.
+    ///
+    /// A fixed window can't serve both a sparse acoustic mix and a dense,
+    /// heavily-limited one. The loud mix doesn't merely sit higher — it barely
+    /// moves, riding a few dB under its limiter, so any window wide enough for
+    /// the acoustic track renders it as four motionless bars. Tracking both
+    /// edges lets the window slide *and* close in, so a small dynamic range is
+    /// spread across the full height instead of vanishing.
+    ///
+    /// How fast the window closes back in once the extremes stop arriving. Slow
+    /// enough that the window describes the passage, not the current beat.
+    private static let windowRelaxDBPerSecond: Float = 1.0
+
+    /// How fast each edge reaches out to a new extreme. Snapping to the exact
+    /// min/max instead lets one freak-quiet frame set the floor tens of dB below
+    /// anything the music does, and the window then describes that outlier for
+    /// the rest of the song. The lower edge is the more exposed of the two, so
+    /// it moves more cautiously.
+    private static let windowRiseSeconds: Float = 0.15
+    private static let windowFallSeconds: Float = 0.5
+
+    /// Never let the window close below this, or a quiet passage gets stretched
+    /// until its noise floor looks like music.
+    private static let minWindowDB: Float = 6
+
+    /// Nor let it open wider than this. Without a cap, one outlier sets an edge
+    /// that takes minutes to relax back, and everything in between reads flat.
+    private static let maxWindowDB: Float = 42
+
+    /// Frames below this carry no signal at all — digital silence lands near
+    /// -180dB. They must not touch the window, or leading silence drags its
+    /// floor to the numeric bottom and the whole track plays out against it.
+    private static let noSignalDB: Float = -95
+
+    /// A band whose upper edge sits below this reads as silence.
+    private static let silenceDB: Float = -70
+
+
+    fileprivate func process(_ bufferList: UnsafeMutablePointer<AudioBufferList>, frames: Int) {
+        guard frames > 0 else { return }
+        let abl = UnsafeMutableAudioBufferListPointer(bufferList)
+        guard let first = abl.first, let raw = first.mData else { return }
+
+        let n = Self.fftSize
+        let src = raw.bindMemory(to: Float.self,
+                                 capacity: Int(first.mDataByteSize) / MemoryLayout<Float>.size)
+        let floatCount = Int(first.mDataByteSize) / MemoryLayout<Float>.size
+        let available = isInterleaved && channelCount > 1
+            ? min(frames, floatCount / channelCount)
+            : min(frames, floatCount)
+        guard available > 0 else { return }
+
+        // Walk the whole buffer in FFT-sized blocks. The tap can hand us far more
+        // than one window at a time; analyzing only the first block would drop
+        // most of the audio and — because the envelope advances once per call —
+        // stretch every time constant by however many blocks went unread.
+        var offset = 0
+        while offset + n <= available {
+            if isInterleaved, channelCount > 1 {
+                let base = src.advanced(by: offset * channelCount)
+                vDSP_vadd(base, vDSP_Stride(channelCount),
+                          base.advanced(by: 1), vDSP_Stride(channelCount),
+                          ring, 1, vDSP_Length(n))
+                var half: Float = 0.5
+                vDSP_vsmul(ring, 1, &half, ring, 1, vDSP_Length(n))
+            } else {
+                memcpy(ring, src.advanced(by: offset), n * MemoryLayout<Float>.size)
+            }
+            analyze(blockFrames: n)
+            offset += n
+        }
+    }
+
+    /// One FFT over `ring`, folded into the published levels.
+    private func analyze(blockFrames: Int) {
+        guard let fftSetup else { return }
+        let n = Self.fftSize
+        let take = blockFrames
+
+        vDSP_vmul(ring, 1, window, 1, mono, 1, vDSP_Length(n))
+
+        var split = DSPSplitComplex(realp: realp, imagp: imagp)
+        mono.withMemoryRebound(to: DSPComplex.self, capacity: n / 2) { ptr in
+            vDSP_ctoz(ptr, 2, &split, 1, vDSP_Length(n / 2))
+        }
+        vDSP_fft_zrip(fftSetup, &split, 1, Self.log2n, FFTDirection(FFT_FORWARD))
+        vDSP_zvabs(&split, 1, magnitudes, 1, vDSP_Length(Self.binCount))
+
+        // vDSP's real FFT returns doubled magnitudes; scale back before dB.
+        var scale: Float = 1.0 / Float(2 * n)
+        vDSP_vsmul(magnitudes, 1, &scale, magnitudes, 1, vDSP_Length(Self.binCount))
+
+        var sawSignal = false
+
+        // Smoothing coefficients derived from elapsed time, so the envelope
+        // behaves the same whatever buffer size the tap hands us.
+        let dt = Float(take) / Float(sampleRate)
+        let attackCoefficient = 1 - expf(-dt / Self.attackSeconds)
+        let releaseCoefficient = 1 - expf(-dt / Self.releaseSeconds)
+        let relax = Self.windowRelaxDBPerSecond * dt
+        let riseCoefficient = 1 - expf(-dt / Self.windowRiseSeconds)
+        let fallCoefficient = 1 - expf(-dt / Self.windowFallSeconds)
+
+        for i in 0..<AudioSpectrum.bandCount {
+            let lo = Int(binLo[i])
+            let hi = Int(binHi[i])
+            guard hi >= lo else { continue }
+
+            var sum: Float = 0
+            vDSP_sve(magnitudes.advanced(by: lo), 1, &sum, vDSP_Length(hi - lo + 1))
+            let mean = sum / Float(hi - lo + 1)
+            if mean > 1e-7 { sawSignal = true }
+
+            let db = 20 * log10f(max(mean, 1e-9))
+
+            // Move the window's edges toward what this band is actually doing:
+            // snap out to a new extreme, creep back in otherwise.
+            var hiDB = windowHiDB[i]
+            var loDB = windowLoDB[i]
+            // Reach out toward a new extreme, relax back when none arrives.
+            // Silent frames are skipped entirely.
+            if db > Self.noSignalDB {
+                if db > hiDB { hiDB += (db - hiDB) * riseCoefficient } else { hiDB -= relax }
+                if db < loDB { loDB += (db - loDB) * fallCoefficient } else { loDB += relax }
+                if hiDB - loDB > Self.maxWindowDB {
+                    loDB = hiDB - Self.maxWindowDB
+                }
+                if hiDB - loDB < Self.minWindowDB {
+                    let mid = (hiDB + loDB) * 0.5
+                    hiDB = mid + Self.minWindowDB * 0.5
+                    loDB = mid - Self.minWindowDB * 0.5
+                }
+            }
+            windowHiDB[i] = hiDB
+            windowLoDB[i] = loDB
+
+            var target: Float = 0
+            if hiDB > Self.silenceDB {
+                target = (db - loDB) / (hiDB - loDB)
+                target = min(max(target, 0), 1)
+            }
+
+            let previous = levels[i]
+            let coefficient = target > previous ? attackCoefficient : releaseCoefficient
+            levels[i] = previous + (target - previous) * coefficient
+        }
+
+        if sawSignal { liveFlag.pointee = 1 }
+    }
+}

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -533,6 +533,10 @@ final class PlayerService: ObservableObject {
         scrobbled = false
         isPlaying = true
         lyricsCursor.activeIndex = nil
+        // Before the URL is even resolved: holds the bars still rather than
+        // letting them fall back to the decorative animation for the moment it
+        // takes to find out whether this source can be tapped.
+        AudioSpectrum.shared.beginPreparing()
         resolveGeneration += 1
         let generation = resolveGeneration
 
@@ -605,8 +609,9 @@ final class PlayerService: ObservableObject {
         let item = AVPlayerItem(asset: asset)
         if let assetTrack, let mix = AudioSpectrum.shared.makeAudioMix(for: assetTrack) {
             item.audioMix = mix
+        } else {
+            AudioSpectrum.shared.markUntappable()
         }
-        AudioSpectrum.shared.reset()
 
         if let old = endObserver {
             NotificationCenter.default.removeObserver(old)

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -323,6 +323,7 @@ final class PlayerService: ObservableObject {
         if isPlaying {
             engine.pause()
             isPlaying = false
+            AudioSpectrum.shared.reset()
         } else if engine.currentItem == nil {
             // Restored session: re-resolve the source.
             startPlaying(track, indexUnchanged: true)
@@ -337,6 +338,7 @@ final class PlayerService: ObservableObject {
     func pause() {
         engine.pause()
         isPlaying = false
+        AudioSpectrum.shared.reset()
         NowPlayingManager.shared.updateElapsed(progress, rate: 0)
     }
 
@@ -591,7 +593,21 @@ final class PlayerService: ObservableObject {
             ToastCenter.shared.show(String(localized: "VIP 歌曲，当前为试听片段"))
         }
 
-        let item = AVPlayerItem(url: url)
+        // Resolve the asset's audio track before the item goes live: an audio mix
+        // attached after playback starts is silently ignored, so the spectrum tap
+        // has to be spliced in here or not at all. Sources that refuse byte-range
+        // requests never resolve a track — those play untapped and the UI falls
+        // back to its decorative animation.
+        let asset = AVURLAsset(url: url)
+        let assetTrack = await loadAudioTrack(from: asset, timeout: 2)
+        guard generation == resolveGeneration else { return }
+
+        let item = AVPlayerItem(asset: asset)
+        if let assetTrack, let mix = AudioSpectrum.shared.makeAudioMix(for: assetTrack) {
+            item.audioMix = mix
+        }
+        AudioSpectrum.shared.reset()
+
         if let old = endObserver {
             NotificationCenter.default.removeObserver(old)
         }
@@ -609,6 +625,23 @@ final class PlayerService: ObservableObject {
         if let time = data?.time, time > 0 {
             duration = TimeInterval(time) / 1000
             NowPlayingManager.shared.updateMetadata(for: track, duration: duration)
+        }
+    }
+
+    /// Resolves the asset's audio track, giving up after `timeout` so a slow or
+    /// uncooperative source delays playback no longer than it would today.
+    private func loadAudioTrack(from asset: AVURLAsset, timeout: TimeInterval) async -> AVAssetTrack? {
+        await withTaskGroup(of: AVAssetTrack?.self) { group in
+            group.addTask {
+                try? await asset.loadTracks(withMediaType: .audio).first
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
         }
     }
 

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -93,6 +93,18 @@ final class PlaybackClock: ObservableObject {
     @Published var progress: TimeInterval = 0
 }
 
+/// Which lyric line is current.
+///
+/// Every lyric view used to derive this itself, which meant observing the clock
+/// and re-rendering on every tick just to discover the line hadn't changed —
+/// and for the now-playing page, whose body is the whole immersive layout, that
+/// was five full re-evaluations a second. Computing it once here and publishing
+/// only on a change turns that into one re-render per lyric line.
+@MainActor
+final class LyricsCursor: ObservableObject {
+    @Published var activeIndex: Int?
+}
+
 @MainActor
 final class PlayerService: ObservableObject {
     static let shared = PlayerService()
@@ -112,6 +124,7 @@ final class PlayerService: ObservableObject {
     @Published private(set) var unblockSource: String?
     @Published private(set) var isTrial = false
     let clock = PlaybackClock()
+    let lyricsCursor = LyricsCursor()
     /// Passthrough to the clock so existing `progress` reads/writes keep working.
     var progress: TimeInterval {
         get { clock.progress }
@@ -204,7 +217,17 @@ final class PlayerService: ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, !self.isScrubbing else { return }
                 let seconds = time.seconds
-                if seconds.isFinite, abs(seconds - self.progress) > 0.05 {
+                guard seconds.isFinite else { return }
+
+                // Lyrics need this cadence to stay in sync; the cursor itself
+                // only publishes when the line actually changes.
+                self.updateLyricsCursor(at: seconds)
+
+                // The scrubber does not. Publishing the position every tick
+                // re-renders it — and SwiftUI rebuilds the display list for the
+                // whole tree each time — to move the thumb a fraction of a
+                // pixel. Half a second is still smoother than the eye needs.
+                if abs(seconds - self.progress) > 0.45 {
                     self.progress = seconds
                     NowPlayingManager.shared.updateElapsed(seconds, rate: self.isPlaying ? 1 : 0)
                 }
@@ -339,8 +362,18 @@ final class PlayerService: ObservableObject {
         startPlaying(activeQueue[idx])
     }
 
+    /// Recomputes the current lyric line, publishing only on a change.
+    /// The lead makes a line light up just before it is sung.
+    private func updateLyricsCursor(at seconds: TimeInterval) {
+        let index = lyrics?.activeIndex(at: seconds + 0.2)
+        if index != lyricsCursor.activeIndex {
+            lyricsCursor.activeIndex = index
+        }
+    }
+
     func seek(to seconds: TimeInterval) {
         progress = seconds
+        updateLyricsCursor(at: seconds)
         engine.seek(to: CMTime(seconds: seconds, preferredTimescale: 600),
                     toleranceBefore: .zero, toleranceAfter: .zero)
         NowPlayingManager.shared.updateElapsed(seconds, rate: isPlaying ? 1 : 0)
@@ -497,6 +530,7 @@ final class PlayerService: ObservableObject {
         lyrics = nil
         scrobbled = false
         isPlaying = true
+        lyricsCursor.activeIndex = nil
         resolveGeneration += 1
         let generation = resolveGeneration
 
@@ -582,6 +616,7 @@ final class PlayerService: ObservableObject {
         let response = try? await NeteaseAPI.lyric(id: track.id)
         guard generation == resolveGeneration else { return }
         lyrics = response.map(LyricsParser.parse)
+        updateLyricsCursor(at: progress)
     }
 
     // MARK: - Scrobble

--- a/Sources/Kumone/DesignSystem/Cards.swift
+++ b/Sources/Kumone/DesignSystem/Cards.swift
@@ -90,6 +90,18 @@ struct Shelf<Content: View>: View {
     let title: LocalizedStringKey
     var seeAll: (() -> Void)?
     var spacing: CGFloat = 16
+    /// Height of one row of cards.
+    ///
+    /// Supplying it lets the shelf build its cards lazily, which matters more
+    /// than it sounds: a plain `HStack` instantiates every card in the shelf and
+    /// keeps it in the responder tree, so hit testing walks all of them on every
+    /// frame of a *vertical* scroll — including the ones scrolled off the side
+    /// and never seen. Measured at roughly half the cost of scrolling the home
+    /// page. It has to be stated rather than measured because a `LazyHStack`
+    /// reports no height until something has been scrolled into view, which
+    /// leaves the enclosing horizontal ScrollView with nothing to lay out
+    /// against and collapses the whole page.
+    var rowHeight: CGFloat?
     @ViewBuilder var content: () -> Content
 
     var body: some View {
@@ -97,14 +109,32 @@ struct Shelf<Content: View>: View {
             SectionHeader(title: title, action: seeAll)
                 .padding(.horizontal, Theme.Layout.contentInset)
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: spacing) {
-                    Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
-                    content()
-                    Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
-                }
-                .padding(.vertical, 6)
+                cards
+                    .padding(.vertical, 6)
             }
             .compatScrollClipDisabled()
+        }
+    }
+
+    private var edgeInset: some View {
+        Color.clear.frame(width: max(0, Theme.Layout.contentInset - spacing), height: 1)
+    }
+
+    @ViewBuilder
+    private var cards: some View {
+        if let rowHeight {
+            LazyHStack(alignment: .top, spacing: spacing) {
+                edgeInset
+                content()
+                edgeInset
+            }
+            .frame(height: rowHeight)
+        } else {
+            HStack(alignment: .top, spacing: spacing) {
+                edgeInset
+                content()
+                edgeInset
+            }
         }
     }
 }

--- a/Sources/Kumone/DesignSystem/Components.swift
+++ b/Sources/Kumone/DesignSystem/Components.swift
@@ -206,6 +206,8 @@ struct PlayOverlayButton: View {
         .opacity(visible ? 1 : 0)
         .scaleEffect(visible ? 1 : 0.7)
         .animation(AppAnimation.spring, value: visible)
+        // Opacity alone leaves it clickable while invisible.
+        .allowsHitTesting(visible)
         #else
         EmptyView()
         #endif
@@ -215,87 +217,219 @@ struct PlayOverlayButton: View {
 // MARK: - Marquee
 
 /// Scrolls text horizontally when it overflows, with faded edges.
+///
+/// Driven by Core Animation rather than SwiftUI. This view sits permanently in
+/// the player bar, and a `repeatForever` SwiftUI animation keeps the entire view
+/// graph re-rendering for as long as it runs — measured at ~15% of a core, for
+/// as long as the current title happened to be long enough to scroll. A
+/// `CABasicAnimation` is handed to the render server once and then costs this
+/// process nothing.
 struct MarqueeText: View {
     let text: String
-    var font: Font = .system(size: 13, weight: .medium)
-
-    @State private var textWidth: CGFloat = 0
-    @State private var containerWidth: CGFloat = 0
-    @State private var offset: CGFloat = 0
-    @State private var animating = false
-
-    private var needsMarquee: Bool { textWidth > containerWidth + 1 }
+    var fontSize: CGFloat = 13
+    var fontWeight: PlatformFont.Weight = .medium
 
     var body: some View {
-        GeometryReader { geo in
-            HStack(spacing: 32) {
-                marqueeLabel
-                if needsMarquee {
-                    marqueeLabel
-                }
-            }
-            .offset(x: offset)
-            .frame(maxHeight: .infinity, alignment: .leading)
-            .onAppear { containerWidth = geo.size.width }
-            .onChange(of: geo.size.width) { newValue in containerWidth = newValue }
-        }
-        .clipped()
-        .mask(edgeFadeMask)
-        .onChange(of: text) { _ in
-            restart()
-        }
-        .onChange(of: needsMarquee) { _ in
-            restart()
-        }
-        .background(
-            Text(text)
-                .font(font)
-                .fixedSize()
-                .hidden()
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.onAppear { textWidth = geo.size.width }
-                            .onChange(of: geo.size.width) { newValue in textWidth = newValue }
-                    }
-                )
-        )
-    }
-
-    private var marqueeLabel: some View {
-        Text(text)
-            .font(font)
-            .lineLimit(1)
-            .fixedSize()
-    }
-
-    private var edgeFadeMask: some View {
-        LinearGradient(
-            stops: [
-                .init(color: animating ? .clear : .black, location: 0),
-                .init(color: .black, location: animating ? 0.06 : 0),
-                .init(color: .black, location: needsMarquee ? 0.94 : 1),
-                .init(color: needsMarquee ? .clear : .black, location: 1),
-            ],
-            startPoint: .leading, endPoint: .trailing
-        )
-    }
-
-    private func restart() {
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            offset = 0
-            animating = false
-        }
-        guard needsMarquee, !Platform.isReduceMotionEnabled else { return }
-        let distance = textWidth + 32
-        let duration = Double(distance) / 24
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-            guard needsMarquee else { return }
-            animating = true
-            withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
-                offset = -distance
-            }
-        }
+        MarqueeTextView.Representable(text: text, fontSize: fontSize, weight: fontWeight)
     }
 }
+
+final class MarqueeTextView: PlatformView {
+    /// Gap between the two copies of the text.
+    private static let gap: CGFloat = 32
+    /// Points per second.
+    private static let speed: CGFloat = 24
+    /// Pause before a new title starts travelling, so it can be read first.
+    private static let leadIn: CFTimeInterval = 1.6
+    private static let fadeFraction = 0.06
+
+    private let scroller = CALayer()
+    private let first = CATextLayer()
+    private let second = CATextLayer()
+    private let fade = CAGradientLayer()
+
+    private var text: String
+    private var fontSize: CGFloat
+    private var weight: PlatformFont.Weight
+    private var textWidth: CGFloat = 0
+    /// Guards against re-running layout on every display cycle: the host view
+    /// calls layout() each frame while an animation is in flight, and tearing
+    /// the animation down and rebuilding it there costs more than the SwiftUI
+    /// version ever did.
+    private var laidOutFor: CGSize = .zero
+    private var needsMarquee: Bool { textWidth > bounds.width + 1 }
+
+    init(text: String, fontSize: CGFloat, weight: PlatformFont.Weight) {
+        self.text = text
+        self.fontSize = fontSize
+        self.weight = weight
+        super.init(frame: .zero)
+        #if os(macOS)
+        wantsLayer = true
+        #endif
+        layer?.addSublayer(scroller)
+        scroller.addSublayer(first)
+        scroller.addSublayer(second)
+        layer?.mask = fade
+        fade.startPoint = CGPoint(x: 0, y: 0.5)
+        fade.endPoint = CGPoint(x: 1, y: 0.5)
+        for textLayer in [first, second] {
+            textLayer.contentsScale = 2
+            textLayer.truncationMode = .none
+            textLayer.isWrapped = false
+        }
+        applyText()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    func update(text: String, fontSize: CGFloat, weight: PlatformFont.Weight) {
+        guard text != self.text || fontSize != self.fontSize || weight != self.weight else { return }
+        self.text = text
+        self.fontSize = fontSize
+        self.weight = weight
+        applyText()
+        relayout()
+    }
+
+    private var font: PlatformFont { .systemFont(ofSize: fontSize, weight: weight) }
+
+    private var labelColor: CGColor {
+        #if os(macOS)
+        return NSColor.labelColor.cgColor
+        #else
+        return UIColor.label.cgColor
+        #endif
+    }
+
+    private func applyText() {
+        let font = self.font
+        textWidth = (text as NSString).size(withAttributes: [.font: font]).width.rounded(.up)
+        for textLayer in [first, second] {
+            textLayer.string = text
+            textLayer.font = font
+            textLayer.fontSize = fontSize
+            textLayer.foregroundColor = labelColor
+        }
+    }
+
+    #if os(macOS)
+    override func layout() {
+        super.layout()
+        guard bounds.size != laidOutFor else { return }
+        relayout()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        // A CGColor is a snapshot; unlike a dynamic NSColor it won't follow the
+        // appearance on its own.
+        first.foregroundColor = labelColor
+        second.foregroundColor = labelColor
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        let scale = window?.backingScaleFactor ?? 2
+        first.contentsScale = scale
+        second.contentsScale = scale
+        relayout()
+    }
+    #else
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard bounds.size != laidOutFor else { return }
+        relayout()
+    }
+
+    override func traitCollectionDidChange(_ previous: UITraitCollection?) {
+        super.traitCollectionDidChange(previous)
+        first.foregroundColor = labelColor
+        second.foregroundColor = labelColor
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        let scale = window?.screen.scale ?? 2
+        first.contentsScale = scale
+        second.contentsScale = scale
+        relayout()
+    }
+    #endif
+
+    private func relayout() {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+        laidOutFor = bounds.size
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        let lineHeight = ceil(font.ascender - font.descender)
+        let y = ((bounds.height - lineHeight) / 2).rounded()
+        first.frame = CGRect(x: 0, y: y, width: textWidth, height: lineHeight)
+        second.frame = CGRect(x: textWidth + Self.gap, y: y, width: textWidth, height: lineHeight)
+        second.isHidden = !needsMarquee
+        scroller.anchorPoint = .zero
+        scroller.bounds = CGRect(x: 0, y: 0,
+                                 width: textWidth * 2 + Self.gap, height: bounds.height)
+        scroller.position = .zero
+        fade.frame = bounds
+        fade.colors = fadeColors()
+        fade.locations = fadeLocations()
+
+        CATransaction.commit()
+        restartAnimation()
+    }
+
+    private func fadeColors() -> [CGColor] {
+        let opaque = PlatformColor.black.cgColor
+        let clear = PlatformColor.black.withAlphaComponent(0).cgColor
+        guard needsMarquee else { return [opaque, opaque, opaque, opaque] }
+        return [clear, opaque, opaque, clear]
+    }
+
+    private func fadeLocations() -> [NSNumber] {
+        guard needsMarquee else { return [0, 0, 1, 1] }
+        return [0, NSNumber(value: Self.fadeFraction),
+                NSNumber(value: 1 - Self.fadeFraction), 1]
+    }
+
+    private func restartAnimation() {
+        scroller.removeAnimation(forKey: "marquee")
+        guard needsMarquee, !Platform.isReduceMotionEnabled else { return }
+
+        let distance = textWidth + Self.gap
+        let animation = CABasicAnimation(keyPath: "position.x")
+        animation.byValue = -distance
+        animation.duration = CFTimeInterval(distance / Self.speed)
+        animation.repeatCount = .infinity
+        animation.isRemovedOnCompletion = false
+        animation.beginTime = CACurrentMediaTime() + Self.leadIn
+        scroller.add(animation, forKey: "marquee")
+    }
+
+    // MARK: Bridge
+
+    struct Representable: PlatformViewRepresentable {
+        let text: String
+        let fontSize: CGFloat
+        let weight: PlatformFont.Weight
+
+        #if os(macOS)
+        func makeNSView(context: Context) -> MarqueeTextView {
+            MarqueeTextView(text: text, fontSize: fontSize, weight: weight)
+        }
+        func updateNSView(_ view: MarqueeTextView, context: Context) {
+            view.update(text: text, fontSize: fontSize, weight: weight)
+        }
+        #else
+        func makeUIView(context: Context) -> MarqueeTextView {
+            MarqueeTextView(text: text, fontSize: fontSize, weight: weight)
+        }
+        func updateUIView(_ view: MarqueeTextView, context: Context) {
+            view.update(text: text, fontSize: fontSize, weight: weight)
+        }
+        #endif
+    }
+}
+

--- a/Sources/Kumone/DesignSystem/Theme.swift
+++ b/Sources/Kumone/DesignSystem/Theme.swift
@@ -22,6 +22,11 @@ enum Theme {
     enum Layout {
         static let contentInset: CGFloat = 24
         static let cardSize: CGFloat = 160
+        /// Row height for a shelf of cover cards: artwork, then up to two lines
+        /// of title and one of subtitle.
+        static let coverShelfHeight: CGFloat = 226
+        /// Row height for a shelf of artist cards: circular artwork, one name.
+        static let artistShelfHeight: CGFloat = 196
         static let sidebarWidth: CGFloat = 220
         static let playerBarHeight: CGFloat = 56
         /// Gap between the floating player bar and the window's bottom edge.

--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -153,7 +153,7 @@ struct HomeView: View {
             }
 
             if !model.recommendPlaylists.isEmpty {
-                Shelf(title: "推荐歌单") {
+                Shelf(title: "推荐歌单", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(Array(model.recommendPlaylists.prefix(12).enumerated()), id: \.element.id) { index, playlist in
                         playlistCard(playlist)
                             .staggeredAppearance(index: index, id: "home-rec-\(playlist.id)")
@@ -162,7 +162,7 @@ struct HomeView: View {
             }
 
             if !model.radarPlaylists.isEmpty {
-                Shelf(title: "雷达歌单") {
+                Shelf(title: "雷达歌单", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.radarPlaylists) { radar in
                         NavigationLink(value: Destination.playlist(radar.id)) {
                             CoverCardBody(
@@ -179,7 +179,7 @@ struct HomeView: View {
             }
 
             if !model.toplists.isEmpty {
-                Shelf(title: "排行榜", seeAll: nil) {
+                Shelf(title: "排行榜", seeAll: nil, rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.toplists) { toplist in
                         NavigationLink(value: Destination.playlist(toplist.id)) {
                             toplistCard(toplist)
@@ -190,7 +190,7 @@ struct HomeView: View {
             }
 
             if !model.newAlbums.isEmpty {
-                Shelf(title: "新碟上架") {
+                Shelf(title: "新碟上架", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.newAlbums) { album in
                         albumCard(album)
                     }
@@ -198,7 +198,7 @@ struct HomeView: View {
             }
 
             if !model.topArtists.isEmpty {
-                Shelf(title: "推荐歌手") {
+                Shelf(title: "推荐歌手", rowHeight: Theme.Layout.artistShelfHeight) {
                     ForEach(model.topArtists) { artist in
                         artistCard(artist)
                     }

--- a/Sources/Kumone/Features/Player/DesktopLyrics.swift
+++ b/Sources/Kumone/Features/Player/DesktopLyrics.swift
@@ -118,13 +118,13 @@ private struct DesktopLyricsSurface: View {
 
 private struct DesktopLyricsBox: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     private var currentLine: LyricLine? {
-        guard player.isPlaying || clock.progress > 0,
+        guard player.isPlaying || PlayerService.shared.progress > 0,
               let lyrics = player.lyrics, !lyrics.isEmpty,
-              let index = lyrics.activeIndex(at: clock.progress + 0.2) else { return nil }
+              let index = lyricsCursor.activeIndex else { return nil }
         return lyrics.lines[index]
     }
 

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// large artwork on the left, big synced lyrics on the right.
 struct NowPlayingView: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
     #if os(iOS)
@@ -124,6 +124,20 @@ struct NowPlayingView: View {
         #else
         return true
         #endif
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
+        }
     }
 
     // MARK: - Backdrop
@@ -552,14 +566,19 @@ struct NowPlayingView: View {
                         startPoint: .top, endPoint: .bottom
                     )
                 )
-                .onChange(of: clock.progress) { _ in
-                    let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                .onChange(of: lyricsCursor.activeIndex) { index in
                     guard index != activeIndex else { return }
                     activeIndex = index
                     guard !isUserScrolling, let index else { return }
                     withAnimation(.spring(response: 0.8, dampingFraction: 0.85)) {
                         proxy.scrollTo(index, anchor: .center)
                     }
+                }
+                .onAppear {
+                    // The cursor only fires on a line change, which can be many
+                    // seconds away — on re-entering the page, adopt where the
+                    // song already is instead of waiting for the next line.
+                    adoptCursor(proxy: proxy)
                 }
                 .onChange(of: player.currentTrack?.id) { _ in
                     activeIndex = nil
@@ -627,7 +646,7 @@ struct NowPlayingView: View {
 #if os(iOS)
 private struct IOSImmersiveLyricsColumn: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     @State private var activeIndex: Int?
@@ -651,14 +670,16 @@ private struct IOSImmersiveLyricsColumn: View {
                     }
                     .mask(edgeMask)
                     .accessibilityIdentifier("syncedLyricsScroll")
-                    .onChange(of: clock.progress) { _ in
-                        let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                    .onChange(of: lyricsCursor.activeIndex) { index in
                         guard index != activeIndex else { return }
                         activeIndex = index
                         guard !isUserScrolling, let index else { return }
                         withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.38)) {
                             proxy.scrollTo(index, anchor: .center)
                         }
+                    }
+                    .onAppear {
+                        adoptCursor(proxy: proxy)
                     }
                     .onChange(of: player.currentTrack?.id) { _ in
                         activeIndex = nil
@@ -699,6 +720,20 @@ private struct IOSImmersiveLyricsColumn: View {
         }
         .onDisappear {
             resumeTask?.cancel()
+        }
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
         }
     }
 
@@ -1278,11 +1313,11 @@ struct MiniLyricsView: View {
     let onOpen: () -> Void
 
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
 
     private var lines: (previous: LyricLine?, current: LyricLine?, next: LyricLine?) {
         guard let lyrics = player.lyrics, !lyrics.isEmpty else { return (nil, nil, nil) }
-        guard let index = lyrics.activeIndex(at: clock.progress + 0.2) else {
+        guard let index = lyricsCursor.activeIndex else {
             return (nil, nil, lyrics.lines.first)
         }
         let all = lyrics.lines

--- a/Sources/Kumone/Features/Player/Panels.swift
+++ b/Sources/Kumone/Features/Player/Panels.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct LyricsPanel: View {
     @EnvironmentObject private var player: PlayerService
-    @ObservedObject private var clock = PlayerService.shared.clock
+    @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var settings: SettingsManager
 
     @State private var activeIndex: Int?
@@ -69,14 +69,16 @@ struct LyricsPanel: View {
                     }
                     .padding(.horizontal, 20)
                 }
-                .onChange(of: clock.progress) { _ in
-                    let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                .onChange(of: lyricsCursor.activeIndex) { index in
                     guard index != activeIndex else { return }
                     activeIndex = index
                     guard !isUserScrolling, let index else { return }
                     withAnimation(.spring(response: 0.7, dampingFraction: 0.85)) {
                         proxy.scrollTo(index, anchor: .center)
                     }
+                }
+                .onAppear {
+                    adoptCursor(proxy: proxy)
                 }
                 .onChange(of: player.currentTrack?.id) { _ in
                     activeIndex = nil
@@ -106,6 +108,20 @@ struct LyricsPanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             EmptyStateView(icon: "quote.bubble", title: "暂无歌词")
+        }
+    }
+
+
+    /// Jump straight to the line the song is on. Used when the view appears,
+    /// where waiting for the next line change would leave the lyrics parked at
+    /// the top. Scrolling is deferred a turn: the list has not laid out yet
+    /// while `onAppear` runs, and `scrollTo` on an unlaid list does nothing.
+    private func adoptCursor(proxy: ScrollViewProxy) {
+        let index = lyricsCursor.activeIndex
+        activeIndex = index
+        guard let index else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(index, anchor: .center)
         }
     }
 

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -149,7 +149,7 @@ struct TrackRow: View {
                 .frame(width: compactArtworkSize, height: compactArtworkSize)
                 .overlay(alignment: .bottomTrailing) {
                     if hidesLeadingIndex, isCurrent {
-                        PlayingIndicator(animating: player.isPlaying)
+                        PlayingIndicator(animating: player.isPlaying && !player.showNowPlaying)
                             .padding(5)
                             .background(
                                 .ultraThinMaterial,
@@ -178,7 +178,7 @@ struct TrackRow: View {
     private var leadingIndicator: some View {
         ZStack {
             if isCurrent {
-                PlayingIndicator(animating: player.isPlaying)
+                PlayingIndicator(animating: player.isPlaying && !player.showNowPlaying)
             } else if isHovering, isPlayable {
                 Button(action: onPlay) {
                     Image(systemName: "play.fill")
@@ -263,23 +263,163 @@ struct TrackRow: View {
 
 // MARK: - Playing indicator
 
+/// The four bars beside the row that's playing.
+///
+/// Deliberately not a SwiftUI animation. Driving these from `TimelineView` —
+/// as this did for a long time — makes SwiftUI re-evaluate and re-lay-out the
+/// enclosing tree on every tick, and with the now-playing page presented as an
+/// overlay that tree is the entire window. Profiling put the cost at roughly
+/// 30% of a core, for four 14pt bars.
+///
+/// Scaling plain `CALayer`s instead is a compositing change: no `draw`, no
+/// layout invalidation, nothing above it in the tree ever learns a frame
+/// happened.
 struct PlayingIndicator: View {
     var animating: Bool
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1 / 20, paused: !animating)) { context in
-            let t = context.date.timeIntervalSinceReferenceDate
-            HStack(spacing: 2) {
-                ForEach(0..<4, id: \.self) { i in
-                    let phase = t * 2.4 + Double(i) * 0.9
-                    let height: CGFloat = animating ? 4 + 8 * abs(sin(phase)) : 4
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Theme.accent)
-                        .frame(width: 2.5, height: height)
-                }
-            }
-            .frame(height: 14, alignment: .center)
+        SpectrumBars(animating: animating)
+            .frame(width: SpectrumBarsView.width, height: SpectrumBarsView.maxHeight)
+    }
+}
+
+#if os(macOS)
+private struct SpectrumBars: NSViewRepresentable {
+    var animating: Bool
+    func makeNSView(context: Context) -> SpectrumBarsView { SpectrumBarsView() }
+    func updateNSView(_ view: SpectrumBarsView, context: Context) {
+        view.animating = animating
+    }
+    static func dismantleNSView(_ view: SpectrumBarsView, coordinator: ()) {
+        view.animating = false
+    }
+}
+#else
+private struct SpectrumBars: UIViewRepresentable {
+    var animating: Bool
+    func makeUIView(context: Context) -> SpectrumBarsView { SpectrumBarsView() }
+    func updateUIView(_ view: SpectrumBarsView, context: Context) {
+        view.animating = animating
+    }
+    static func dismantleUIView(_ view: SpectrumBarsView, coordinator: ()) {
+        view.animating = false
+    }
+}
+#endif
+
+final class SpectrumBarsView: PlatformView {
+    static let minHeight: CGFloat = 3
+    static let maxHeight: CGFloat = 14
+    static let barWidth: CGFloat = 2.5
+    static let spacing: CGFloat = 2
+    static let width =
+        CGFloat(AudioSpectrum.bandCount) * barWidth
+        + CGFloat(AudioSpectrum.bandCount - 1) * spacing
+
+    private var bars: [CALayer] = []
+    private var timer: Timer?
+    private var startedAt = CACurrentMediaTime()
+
+    var animating = false {
+        didSet {
+            guard animating != oldValue else { return }
+            animating ? start() : stop()
         }
+    }
+
+    init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: Self.width, height: Self.maxHeight))
+        #if os(macOS)
+        wantsLayer = true
+        #endif
+        buildBars()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    deinit { timer?.invalidate() }
+
+    private func buildBars() {
+        guard let host = layer else { return }
+        let color = PlatformColor(Theme.accent).cgColor
+        for _ in 0..<AudioSpectrum.bandCount {
+            let bar = CALayer()
+            bar.backgroundColor = color
+            bar.cornerRadius = 1
+            // Centered anchor so a scale grows the bar symmetrically.
+            bar.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            bar.bounds = CGRect(x: 0, y: 0, width: Self.barWidth, height: Self.maxHeight)
+            host.addSublayer(bar)
+            bars.append(bar)
+        }
+        apply(scaleForAll: Self.minHeight / Self.maxHeight)
+    }
+
+    #if os(macOS)
+    override func layout() {
+        super.layout()
+        positionBars()
+    }
+    #else
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        positionBars()
+    }
+    #endif
+
+    private func positionBars() {
+        for (i, bar) in bars.enumerated() {
+            bar.position = CGPoint(
+                x: CGFloat(i) * (Self.barWidth + Self.spacing) + Self.barWidth / 2,
+                y: bounds.midY)
+        }
+    }
+
+    private func start() {
+        guard timer == nil else { return }
+        startedAt = CACurrentMediaTime()
+        // Common mode so the bars keep moving while a list is being scrolled.
+        let timer = Timer(timeInterval: 1.0 / 30, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func stop() {
+        timer?.invalidate()
+        timer = nil
+        apply(scaleForAll: Self.minHeight / Self.maxHeight)
+    }
+
+    @MainActor
+    private func tick() {
+        let live = AudioSpectrum.shared.isLive
+        let elapsed = CACurrentMediaTime() - startedAt
+        let span = Self.maxHeight - Self.minHeight
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for (i, bar) in bars.enumerated() {
+            // Real band levels when the tap is feeding us; otherwise the old
+            // decorative sine, so untappable sources still look alive.
+            let level = live
+                ? CGFloat(AudioSpectrum.shared.level(at: i))
+                : CGFloat(abs(sin(elapsed * 2.4 + Double(i) * 0.9)))
+            let height = Self.minHeight + span * level
+            bar.transform = CATransform3DMakeScale(1, height / Self.maxHeight, 1)
+        }
+        CATransaction.commit()
+    }
+
+    private func apply(scaleForAll scale: CGFloat) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for bar in bars {
+            bar.transform = CATransform3DMakeScale(1, scale, 1)
+        }
+        CATransaction.commit()
     }
 }
 

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -395,7 +395,26 @@ final class SpectrumBarsView: PlatformView {
 
     @MainActor
     private func tick() {
-        let live = AudioSpectrum.shared.isLive
+        let spectrum = AudioSpectrum.shared
+        let live: Bool
+        switch spectrum.tapState {
+        case .tapped:
+            // Samples may still be a few hundred milliseconds out while the
+            // source buffers. Hold still through that rather than animating,
+            // which reads as a glitch right as a song starts.
+            live = spectrum.isLive
+            guard live else {
+                apply(scaleForAll: Self.minHeight / Self.maxHeight)
+                return
+            }
+        case .untappable:
+            live = false
+        case .idle, .preparing:
+            // Not yet known whether this source can be tapped.
+            apply(scaleForAll: Self.minHeight / Self.maxHeight)
+            return
+        }
+
         let elapsed = CACurrentMediaTime() - startedAt
         let span = Self.maxHeight - Self.minHeight
 
@@ -405,7 +424,7 @@ final class SpectrumBarsView: PlatformView {
             // Real band levels when the tap is feeding us; otherwise the old
             // decorative sine, so untappable sources still look alive.
             let level = live
-                ? CGFloat(AudioSpectrum.shared.level(at: i))
+                ? CGFloat(spectrum.level(at: i))
                 : CGFloat(abs(sin(elapsed * 2.4 + Double(i) * 0.9)))
             let height = Self.minHeight + span * level
             bar.transform = CATransform3DMakeScale(1, height / Self.maxHeight, 1)


### PR DESCRIPTION
> **依赖 #38。** 本分支基于它，所以下方 diff 目前也包含 #38 的提交。先合并 #38，本 PR 会自动收敛为只剩三个文件：`AudioSpectrum.swift`、`PlayerService.swift`、`TrackList.swift`。

正在播放那一行旁边的四根柱子，此前跟着 sin 波跳。现在它跟着音乐。

## 关于 #14

那个 issue 当时以「真实频谱需要 `AVAudioEngine`，且对远程流不可行」为由关闭。**这个结论不成立。** `MTAudioProcessingTap` 不需要更换播放引擎，对远程 progressive 音源同样有效——写代码之前我先端到端验证过。网易返回的也是普通 mp3/flac 而非 DRM，不存在加密问题。

真正的限制是另外两条，而且都是靠实测才发现的：

**audioMix 必须在 player item 上线之前挂载。** 播放开始后再挂会被**静默忽略**——tap 根本不会触发，也没有任何报错。这正是按最直觉的顺序去写就一定会得出「拿不到 PCM」结论的原因。因此必须提前解析 asset 的音轨，代价是**约 140ms 的启动延迟**（实测；其中大部分与 `AVPlayer` 本身要做的 header 请求重叠）。另加 2 秒超时，保证慢音源不会比现状更差。

**不支持 Range 请求的服务器永远解析不出音轨。** 部分第三方解锁音源正是如此。这类音源不挂 tap，UI 保持原来的装饰动画——这就是 `tapState` 的用途。

## 让它真的像音乐

有两处我一开始就搞错了，都是靠测量而非肉眼发现的：

**单一 dB 窗口行不通。** 音乐能量随频率急剧衰减——跨多首真实曲目实测，presence 频段比 bass 低约 30dB——所以共用一个窗口会让低频顶满、高频永远趴在底部。改为每频段独立窗口后，这个倾斜被抵消。

**固定标定同样行不通。** 混音密集、压缩很重的曲目会把每个频段都顶到窗口上沿，于是柱子**恰好在音乐最密集处变成一条直线**——而那正是听众最容易注意到的时刻。现在每个频段的窗口会跟踪它实际产生的电平，既平移也收窄，让很小的动态范围也能铺满整个高度。

我也一度假设「高密度摇滚本身动态范围就小」。写了个离线分析器一测，结论恰好相反——它的原始逐频段 dB 范围比那几首原声曲目**更宽**。动态一直都在，是我的映射把它丢掉了。

## 渲染方式

柱子是被缩放 transform 的 `CALayer`，而不是 `TimelineView` 里的重绘。SwiftUI 动画每 tick 一次就会让外层视图树重新布局，而全屏播放页是以 overlay 呈现的，那棵「外层树」就是整个窗口。全屏页打开时柱子也会暂停——那里本来就看不见它。

无法 tap 的音源回退到原来的 sin 波动画，对它们没有任何退化。

## 一个值得看的 bug 修复

第三个 commit 修的是切歌瞬间柱子会跳一下。**那不是回退动画在闪，而是真实数据——只不过属于上一首歌。**

旧曲目的 tap 会一直运行到它的 player item 真正被替换为止，而新旧 tap 写的是同一份共享存储。所以「换歌时清空存储」毫无作用：旧 tap 在下一次回调就把上一首的电平原样写了回来，并持续到新音源解析完成的那两三百毫秒。加了时序日志后一眼就看到了：`state=preparing live=true l0=0.88`，而新曲目一个采样都还没产生。

现在每个 item 拿到独立的存储，旧 tap 继续写一份没人读的数据，等它被 finalize 时释放。

（这个 bug 我靠推理猜错了两次，加一次日志就定位了。教训记下了。）

## 测试

- 合成纯音：120 / 500 / 1500 / 4000Hz 各自落在预期频段
- 数字静音读数为零，`isLive` 正确置否
- 三首真实曲目 + 一段合成的高密度鼓点素材：四个频段都保持可用的动态范围，无饱和
- FFT 运行在实时音频线程上，因此它触及的一切都是预分配、无锁的，其中不遍历任何 Swift 集合类型

**iOS 未验证**——本机没有 Xcode，iOS target 从未编译过。本次没有新增平台分支，用到的 API 在 iOS 16 上均存在（vDSP、MediaToolbox、`loadTracks`），但合并前需要 CI 确认。

## 可调参数

`AudioSpectrum` 的包络与窗口常量都在 store 顶部（attack/release、窗口回归速率、窗口最小/最大宽度）。柱子的几何尺寸在 `SpectrumBarsView` 里。每一项都注明了它在权衡什么。
