### PR TITLE
feat(ios): add concise now-playing mode

### DIFF
--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -339,10 +339,13 @@ final class PlayerService: ObservableObject {
         startPlaying(activeQueue[idx])
     }
 
-    func seek(to seconds: TimeInterval) {
+    func seek(to seconds: TimeInterval, completion: (@MainActor () -> Void)? = nil) {
         progress = seconds
         engine.seek(to: CMTime(seconds: seconds, preferredTimescale: 600),
-                    toleranceBefore: .zero, toleranceAfter: .zero)
+                    toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            guard let completion else { return }
+            Task { @MainActor in completion() }
+        }
         NowPlayingManager.shared.updateElapsed(seconds, rate: isPlaying ? 1 : 0)
     }
 
@@ -361,6 +364,26 @@ final class PlayerService: ObservableObject {
     func cycleRepeatMode() {
         guard !isFMMode else { return }
         repeatMode = repeatMode.next
+    }
+
+    /// Single-button mode cycle for the iOS minimal transport row:
+    /// sequential → loop all → loop one → shuffle → sequential.
+    func cyclePlaybackMode() {
+        guard !isFMMode else { return }
+        if shuffleEnabled {
+            toggleShuffle()
+            repeatMode = .off
+        } else {
+            switch repeatMode {
+            case .off:
+                repeatMode = .all
+            case .all:
+                repeatMode = .one
+            case .one:
+                repeatMode = .off
+                toggleShuffle()
+            }
+        }
     }
 
     /// Jump to a track in the upcoming list (queue panel click).

--- a/Sources/Kumone/Core/Storage/SettingsManager.swift
+++ b/Sources/Kumone/Core/Storage/SettingsManager.swift
@@ -56,6 +56,7 @@ enum AppAppearance: String, CaseIterable, Identifiable {
 enum NowPlayingMode: String, CaseIterable, Identifiable {
     case classic
     case immersive
+    case minimal
 
     var id: String { rawValue }
 
@@ -63,6 +64,7 @@ enum NowPlayingMode: String, CaseIterable, Identifiable {
         switch self {
         case .classic: return String(localized: "经典模式")
         case .immersive: return String(localized: "沉浸模式")
+        case .minimal: return String(localized: "简洁模式")
         }
     }
 }

--- a/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
@@ -129,7 +129,7 @@ struct IOSNowPlayingPresentation<Content: View>: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let isInteractive = proxy.size.width < 720 && mode == .immersive
+            let isInteractive = proxy.size.width < 720 && mode != .classic
             let usesCustomDrag = isInteractive && !usesSystemInteractiveDismissal
 
             ZStack(alignment: .top) {

--- a/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingPresentation.swift
@@ -94,10 +94,24 @@ private struct DismissNowPlayingActionKey: EnvironmentKey {
     static let defaultValue: (() -> Void)? = nil
 }
 
+struct NowPlayingDismissDragAction {
+    let onChanged: (CGFloat) -> Void
+    let onEnded: (CGFloat, CGFloat) -> Void
+}
+
+private struct DismissNowPlayingDragActionKey: EnvironmentKey {
+    static let defaultValue: NowPlayingDismissDragAction? = nil
+}
+
 extension EnvironmentValues {
     var dismissNowPlayingAction: (() -> Void)? {
         get { self[DismissNowPlayingActionKey.self] }
         set { self[DismissNowPlayingActionKey.self] = newValue }
+    }
+
+    var dismissNowPlayingDragAction: NowPlayingDismissDragAction? {
+        get { self[DismissNowPlayingDragActionKey.self] }
+        set { self[DismissNowPlayingDragActionKey.self] = newValue }
     }
 }
 
@@ -135,6 +149,10 @@ struct IOSNowPlayingPresentation<Content: View>: View {
             ZStack(alignment: .top) {
                 content
                     .environment(\.dismissNowPlayingAction, dismiss)
+                    .environment(
+                        \.dismissNowPlayingDragAction,
+                        dismissDragAction(usesCustomDrag: usesCustomDrag)
+                    )
 
                 if isInteractive {
                     dragIndicator
@@ -185,20 +203,41 @@ struct IOSNowPlayingPresentation<Content: View>: View {
         // oscillation between the finger and the moving hit target.
         DragGesture(minimumDistance: 3, coordinateSpace: .global)
             .onChanged { value in
-                dragOffset = max(value.translation.height, 0)
+                updateDismissDrag(value.translation.height)
             }
             .onEnded { value in
-                if NowPlayingPresentationMetrics.shouldDismiss(
-                    translation: value.translation.height,
-                    predictedTranslation: value.predictedEndTranslation.height
-                ) {
-                    dismiss()
-                } else {
-                    withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
-                        dragOffset = 0
-                    }
-                }
+                finishDismissDrag(
+                    value.translation.height,
+                    value.predictedEndTranslation.height
+                )
             }
+    }
+
+    private func dismissDragAction(usesCustomDrag: Bool) -> NowPlayingDismissDragAction {
+        NowPlayingDismissDragAction(
+            onChanged: { translation in
+                guard usesCustomDrag else { return }
+                updateDismissDrag(translation)
+            },
+            onEnded: finishDismissDrag
+        )
+    }
+
+    private func updateDismissDrag(_ translation: CGFloat) {
+        dragOffset = max(translation, 0)
+    }
+
+    private func finishDismissDrag(_ translation: CGFloat, _ predictedTranslation: CGFloat) {
+        if NowPlayingPresentationMetrics.shouldDismiss(
+            translation: translation,
+            predictedTranslation: predictedTranslation
+        ) {
+            dismiss()
+        } else {
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
+                dragOffset = 0
+            }
+        }
     }
 
     private func dismiss() {

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -9,6 +9,7 @@ struct NowPlayingView: View {
     @EnvironmentObject private var settings: SettingsManager
     #if os(iOS)
     @Environment(\.dismissNowPlayingAction) private var dismissNowPlayingAction
+    @Environment(\.dismissNowPlayingDragAction) private var dismissNowPlayingDragAction
     #endif
 
     @State private var artworkImage: PlatformImage?
@@ -419,6 +420,10 @@ struct NowPlayingView: View {
                 .accessibilityHidden(!showLyricsOnMobile)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .simultaneousGesture(
+                minimalDismissGesture,
+                including: showLyricsOnMobile ? .none : .all
+            )
             .padding(.bottom, 20)
 
             minimalControls
@@ -457,6 +462,27 @@ struct NowPlayingView: View {
     private func toggleMinimalLyrics() {
         guard showLyricsOnMobile || player.lyrics?.isEmpty == false else { return }
         showLyricsOnMobile.toggle()
+    }
+
+    private var minimalDismissGesture: some Gesture {
+        DragGesture(minimumDistance: 3, coordinateSpace: .global)
+            .onChanged { value in
+                guard let dismissNowPlayingDragAction else { return }
+                let translation = value.translation
+                let isDownward = translation.height > 0
+                    && abs(translation.height) > abs(translation.width)
+                dismissNowPlayingDragAction.onChanged(isDownward ? translation.height : 0)
+            }
+            .onEnded { value in
+                guard let dismissNowPlayingDragAction else { return }
+                let translation = value.translation
+                let isDownward = translation.height > 0
+                    && abs(translation.height) > abs(translation.width)
+                dismissNowPlayingDragAction.onEnded(
+                    isDownward ? translation.height : 0,
+                    isDownward ? value.predictedEndTranslation.height : 0
+                )
+            }
     }
     #endif
 

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -70,6 +70,17 @@ struct NowPlayingView: View {
                     .padding(.trailing, 20)
                 }
             }
+            #if os(iOS)
+            .overlay {
+                if settings.nowPlayingMode == .minimal && showQueueOnMobile {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture { showQueueOnMobile = false }
+                        .accessibilityLabel("关闭播放列表")
+                        .accessibilityAddTraits(.isButton)
+                }
+            }
+            #endif
         }
         #if os(macOS)
         // The window toolbar is hidden while this page is up, but SwiftUI keeps
@@ -90,6 +101,11 @@ struct NowPlayingView: View {
         .onChange(of: settings.nowPlayingMode) { _ in
             showLyricsOnMobile = settings.nowPlayingMode == .immersive
             showQueueOnMobile = false
+        }
+        .onChange(of: player.currentTrack?.id) { _ in
+            if settings.nowPlayingMode == .minimal {
+                showLyricsOnMobile = false
+            }
         }
         #endif
         #if os(macOS)
@@ -186,6 +202,8 @@ struct NowPlayingView: View {
             classicCompactLayout(size: size)
         case .immersive:
             immersiveCompactLayout(size: size)
+        case .minimal:
+            minimalCompactLayout(size: size)
         }
         #else
         classicCompactLayout(size: size)
@@ -362,6 +380,83 @@ struct NowPlayingView: View {
         withAnimation(ImmersiveArtworkTransition.animation) {
             showQueueOnMobile.toggle()
         }
+    }
+
+    private func minimalCompactLayout(size: CGSize) -> some View {
+        let contentWidth = max(size.width - 64, 0)
+        let artworkDimension = min(contentWidth, size.height * 0.52, 378)
+
+        return VStack(spacing: 0) {
+            ZStack(alignment: .top) {
+                Color.clear
+                MinimalTrackInfoRow(metadataOnly: true)
+                    .padding(.top, NowPlayingPresentationMetrics.immersiveHeaderTopInset)
+                    .opacity(showLyricsOnMobile ? 1 : 0)
+                    .accessibilityHidden(!showLyricsOnMobile)
+            }
+            .frame(height: 90)
+
+            ZStack(alignment: .top) {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: toggleMinimalLyrics)
+
+                artworkView(size: artworkDimension)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: toggleMinimalLyrics)
+                    .accessibilityIdentifier("immersiveArtwork")
+                    .accessibilityLabel("显示歌词")
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityAction { toggleMinimalLyrics() }
+                    .opacity(showLyricsOnMobile ? 0 : 1)
+                    .allowsHitTesting(!showLyricsOnMobile)
+
+                IOSMinimalLyricsColumn {
+                    showLyricsOnMobile = false
+                }
+                .opacity(showLyricsOnMobile ? 1 : 0)
+                .allowsHitTesting(showLyricsOnMobile)
+                .accessibilityHidden(!showLyricsOnMobile)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .padding(.bottom, 20)
+
+            minimalControls
+        }
+        .frame(width: contentWidth)
+        .padding(.horizontal, 32)
+        .padding(.bottom, 32)
+        .animation(.easeInOut(duration: 0.22), value: showLyricsOnMobile)
+    }
+
+    private var minimalControls: some View {
+        VStack(spacing: 22) {
+            ZStack {
+                MinimalTrackInfoRow()
+                    .opacity(showLyricsOnMobile ? 0 : 1)
+                    .allowsHitTesting(!showLyricsOnMobile)
+                    .accessibilityHidden(showLyricsOnMobile)
+                MinimalTrackInfoRow(actionsOnly: true)
+                    .opacity(showLyricsOnMobile ? 1 : 0)
+                    .allowsHitTesting(showLyricsOnMobile)
+                    .accessibilityHidden(!showLyricsOnMobile)
+            }
+            .frame(height: 44)
+            NowPlayingScrubber()
+                .padding(.horizontal, 2)
+                .padding(.top, 16)
+            MinimalTransportControls(
+                backdrop: colors,
+                showQueue: $showQueueOnMobile
+            )
+                .padding(.horizontal, 2)
+        }
+        .accessibilityIdentifier("immersiveControls")
+    }
+
+    private func toggleMinimalLyrics() {
+        guard showLyricsOnMobile || player.lyrics?.isEmpty == false else { return }
+        showLyricsOnMobile.toggle()
     }
     #endif
 
@@ -1194,6 +1289,634 @@ private struct TranslucentSliderTrack: View {
     }
 }
 
+private struct IOSMinimalLyricsColumn: View {
+    @EnvironmentObject private var player: PlayerService
+    @ObservedObject private var clock = PlayerService.shared.clock
+    @EnvironmentObject private var settings: SettingsManager
+
+    let onClose: () -> Void
+
+    @State private var activeIndex: Int?
+    @State private var selectedIndex: Int?
+    @State private var nearestIndex: Int?
+    @State private var lineCenters: [Int: CGFloat] = [:]
+    @State private var isDragging = false
+    @State private var suppressesAutoScroll = false
+
+    var body: some View {
+        GeometryReader { geometry in
+            Group {
+                if let lyrics = player.lyrics, !lyrics.isEmpty {
+                    ScrollViewReader { proxy in
+                        ScrollView(showsIndicators: false) {
+                            LazyVStack(alignment: .leading, spacing: 4) {
+                                Color.clear.frame(height: geometry.size.height / 2)
+                                ForEach(lyrics.lines) { line in
+                                    lyricLine(
+                                        line,
+                                        isActive: line.id == activeIndex,
+                                        isSelected: line.id == selectedIndex,
+                                        availableWidth: geometry.size.width
+                                    ) {
+                                        guard let selectedIndex else {
+                                            closeLyrics()
+                                            return
+                                        }
+                                        guard selectedIndex == line.id else {
+                                            self.selectedIndex = nil
+                                            nearestIndex = nil
+                                            guard let activeIndex else { return }
+                                            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                                                proxy.scrollTo(activeIndex, anchor: .center)
+                                            }
+                                            return
+                                        }
+                                        suppressesAutoScroll = true
+                                        player.seek(to: line.time) {
+                                            suppressesAutoScroll = false
+                                        }
+                                        activeIndex = line.id
+                                        self.selectedIndex = nil
+                                        nearestIndex = nil
+                                    }
+                                    .id(line.id)
+                                    .background {
+                                        GeometryReader { lineGeometry in
+                                            Color.clear.preference(
+                                                key: MinimalLyricCentersKey.self,
+                                                value: [
+                                                    line.id: lineGeometry.frame(
+                                                        in: .named("immersiveLyrics")
+                                                    ).midY
+                                                ]
+                                            )
+                                        }
+                                    }
+                                }
+                                Color.clear.frame(height: geometry.size.height / 2)
+                            }
+                            .padding(.horizontal, 2)
+                        }
+                        .coordinateSpace(name: "immersiveLyrics")
+                        .mask(edgeMask)
+                        .contentShape(Rectangle())
+                        .onTapGesture(perform: closeLyrics)
+                        .accessibilityIdentifier("syncedLyricsScroll")
+                        .onPreferenceChange(MinimalLyricCentersKey.self) { centers in
+                            lineCenters = centers
+                            guard isDragging else { return }
+                            nearestIndex = nearestLine(
+                                to: geometry.size.height / 2,
+                                in: centers
+                            )
+                        }
+                        .onAppear {
+                            activeIndex = lyrics.activeIndex(at: clock.progress + 0.2)
+                            if let activeIndex {
+                                Task { @MainActor in
+                                    await Task.yield()
+                                    proxy.scrollTo(activeIndex, anchor: .center)
+                                }
+                            }
+                        }
+                        .onChange(of: clock.progress) { _ in
+                            let index = lyrics.activeIndex(at: clock.progress + 0.2)
+                            guard index != activeIndex else { return }
+                            activeIndex = index
+                            guard !suppressesAutoScroll,
+                                  !isDragging, selectedIndex == nil, let index else { return }
+                            withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.38)) {
+                                proxy.scrollTo(index, anchor: .center)
+                            }
+                        }
+                        .onChange(of: player.currentTrack?.id) { _ in
+                            activeIndex = nil
+                            selectedIndex = nil
+                            nearestIndex = nil
+                            suppressesAutoScroll = false
+                        }
+                        .simultaneousGesture(
+                            DragGesture()
+                                .onChanged { _ in
+                                    if !isDragging {
+                                        selectedIndex = nil
+                                        isDragging = true
+                                    }
+                                    nearestIndex = nearestLine(
+                                        to: geometry.size.height / 2,
+                                        in: lineCenters
+                                    )
+                                }
+                                .onEnded { _ in
+                                    let selection = nearestLine(
+                                        to: geometry.size.height / 2,
+                                        in: lineCenters
+                                    ) ?? nearestIndex
+                                    selectedIndex = selection
+                                    nearestIndex = selection
+                                    isDragging = false
+                                    guard let selection else { return }
+                                    Task { @MainActor in
+                                        await Task.yield()
+                                        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                                            proxy.scrollTo(selection, anchor: .center)
+                                        }
+                                    }
+                                }
+                        )
+                        .overlay {
+                            selectionGuide(lyrics: lyrics)
+                        }
+                    }
+                } else if player.lyrics?.isInstrumental == true {
+                    VStack(spacing: 10) {
+                        Image(systemName: "music.quarternote.3")
+                            .font(.system(size: 36, weight: .light))
+                            .foregroundStyle(.white.opacity(0.4))
+                        Text("纯音乐，请欣赏")
+                            .font(.system(size: 15))
+                            .foregroundStyle(.white.opacity(0.6))
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: closeLyrics)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func selectionGuide(lyrics: ParsedLyrics) -> some View {
+        if let index = isDragging ? nearestIndex : selectedIndex,
+           lyrics.lines.indices.contains(index) {
+            HStack(spacing: 8) {
+                if isDragging {
+                    Canvas { context, size in
+                        var path = Path()
+                        path.move(to: CGPoint(x: 0, y: size.height / 2))
+                        path.addLine(to: CGPoint(x: size.width, y: size.height / 2))
+                        context.stroke(
+                            path,
+                            with: .color(.white.opacity(0.45)),
+                            style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+                        )
+                    }
+                    .frame(height: 1)
+                } else {
+                    Spacer()
+                }
+
+                Text(Formatters.duration(lyrics.lines[index].time))
+                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.72))
+                    .offset(x: 25)
+            }
+            .padding(.horizontal, 2)
+            .allowsHitTesting(false)
+        }
+    }
+
+    private func nearestLine(to guideY: CGFloat, in centers: [Int: CGFloat]) -> Int? {
+        centers.min { abs($0.value - guideY) < abs($1.value - guideY) }?.key
+    }
+
+    private func closeLyrics() {
+        selectedIndex = nil
+        nearestIndex = nil
+        isDragging = false
+        onClose()
+    }
+
+    private var edgeMask: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .clear, location: 0),
+                .init(color: .black, location: 0.12),
+                .init(color: .black, location: 0.85),
+                .init(color: .clear, location: 1),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    private func lyricLine(
+        _ line: LyricLine,
+        isActive: Bool,
+        isSelected: Bool,
+        availableWidth: CGFloat,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 3) {
+                if settings.showLyricsRomaji, let romaji = line.romaji {
+                    Text(romaji)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .scaleEffect(isActive ? 1.02 : 12.0 / 13.0, anchor: .leading)
+                }
+
+                Text(line.text.isEmpty ? "♪" : line.text)
+                    .font(.system(size: 23, weight: .bold))
+                    .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .scaleEffect(isActive ? 1.02 : 19.0 / 23.0, anchor: .leading)
+
+                if settings.showLyricsTranslation, let translation = line.translation {
+                    Text(translation)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .scaleEffect(isActive ? 1.02 : 12.0 / 14.0, anchor: .leading)
+                }
+            }
+            .multilineTextAlignment(.leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.white.opacity(isSelected ? 0.14 : 0))
+            )
+            .contentShape(Rectangle())
+            .padding(.trailing, availableWidth * (1 - 1 / 1.02))
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .animation(.spring(response: 0.28, dampingFraction: 0.9), value: isActive)
+        .animation(.easeOut(duration: 0.18), value: isSelected)
+    }
+}
+
+private struct MinimalLyricCentersKey: PreferenceKey {
+    static var defaultValue: [Int: CGFloat] = [:]
+
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, latest in latest })
+    }
+}
+
+// MARK: - Minimal track info row
+
+private struct MinimalTrackInfoRow: View {
+    @EnvironmentObject private var player: PlayerService
+    @EnvironmentObject private var account: AccountStore
+    @State private var showAddToPlaylist = false
+    @State private var airPlayRequest = 0
+    var metadataOnly = false
+    var actionsOnly = false
+
+    var body: some View {
+        Group {
+            if metadataOnly {
+                metadata(alignment: .center, textAlignment: .center)
+                    .padding(.horizontal, 48)
+            } else if actionsOnly {
+                if let track = player.currentTrack {
+                    HStack {
+                        favoriteButton(for: track)
+                        Spacer()
+                        moreMenu(for: track)
+                    }
+                }
+            } else {
+                HStack(spacing: 8) {
+                    metadata(alignment: .leading, textAlignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if let track = player.currentTrack {
+                        favoriteButton(for: track)
+                        moreMenu(for: track)
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showAddToPlaylist) {
+            if let track = player.currentTrack {
+                AddToPlaylistSheet(track: track)
+            }
+        }
+    }
+
+    private func metadata(
+        alignment: HorizontalAlignment,
+        textAlignment: TextAlignment
+    ) -> some View {
+        VStack(alignment: alignment, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(player.currentTrack?.name ?? "")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                if player.currentTrack?.fee == 1 {
+                    VIPBadge()
+                }
+            }
+            Text(player.currentTrack?.artistNames ?? "")
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.62))
+                .lineLimit(1)
+        }
+        .multilineTextAlignment(textAlignment)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("immersiveTrackMetadata")
+    }
+
+    private func favoriteButton(for track: Track) -> some View {
+        let liked = account.isLiked(track.id)
+        return Button {
+            Task { await account.toggleLike(trackID: track.id) }
+        } label: {
+            Image(systemName: liked ? "heart.fill" : "heart")
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(liked ? Theme.accent : .white.opacity(0.88))
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel(liked ? "取消收藏" : "收藏")
+        .accessibilityIdentifier("immersiveFavoriteButton")
+    }
+
+    private func moreMenu(for track: Track) -> some View {
+        Menu {
+            Button {
+                airPlayRequest += 1
+            } label: {
+                Label("AirPlay", systemImage: "airplayaudio")
+            }
+
+            Button {
+                player.addToPlayNext(track)
+            } label: {
+                Label("下一首播放", systemImage: "text.line.first.and.arrowtriangle.forward")
+            }
+
+            Button {
+                showAddToPlaylist = true
+            } label: {
+                Label("加入歌单…", systemImage: "music.note.list")
+            }
+
+            Divider()
+
+            Button {
+                Platform.copyToPasteboard(
+                    string: "https://music.163.com/#/song?id=\(track.id)"
+                )
+                ToastCenter.shared.show(String(localized: "链接已复制"))
+            } label: {
+                Label("复制链接", systemImage: "link")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(.white.opacity(0.88))
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel("更多操作")
+        .accessibilityIdentifier("immersiveMoreMenu")
+        .background {
+            RoutePickerButton(
+                diameter: 1, glyphSize: 1, request: airPlayRequest,
+                tint: .clear, background: .clear
+            )
+            .opacity(0.01)
+        }
+    }
+}
+
+private struct MinimalTransportControls: View {
+    @EnvironmentObject private var player: PlayerService
+    let backdrop: ArtworkColors
+    @Binding var showQueue: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button {
+                showQueue = true
+            } label: {
+                Image(systemName: "list.bullet")
+                    .font(.system(size: 20, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            }
+            .accessibilityLabel("播放列表")
+            .accessibilityIdentifier("immersivePlaylistButton")
+                .frame(maxWidth: .infinity)
+
+            Button(action: player.isFMMode ? player.fmTrash : player.previous) {
+                Image(systemName: player.isFMMode ? "trash" : "backward.fill")
+                    .font(.system(size: 25, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 58)
+            }
+            .accessibilityLabel(player.isFMMode ? "不喜欢" : "上一首")
+
+            Button(action: player.togglePlayPause) {
+                Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 38, weight: .bold))
+                    .contentTransition(.opacity)
+                    .frame(maxWidth: .infinity, minHeight: 64)
+            }
+            .accessibilityLabel(player.isPlaying ? "暂停" : "播放")
+
+            Button(action: player.next) {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 25, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 58)
+            }
+            .accessibilityLabel("下一首")
+
+            playbackModeButton
+                .frame(maxWidth: .infinity)
+        }
+        .foregroundStyle(.white)
+        .buttonStyle(.pressable)
+        .sheet(isPresented: $showQueue) {
+            queueSheet
+        }
+    }
+
+    @ViewBuilder
+    private var queueSheet: some View {
+        if #available(iOS 16.4, *) {
+            MinimalQueueSheet(backdrop: backdrop)
+                .presentationDetents([.fraction(0.5)])
+                .presentationBackgroundInteraction(.enabled)
+        } else {
+            MinimalQueueSheet(backdrop: backdrop)
+                .presentationDetents([.fraction(0.5)])
+        }
+    }
+
+    @ViewBuilder
+    private var playbackModeButton: some View {
+        if player.isFMMode {
+            Color.clear
+                .frame(height: 44)
+        } else {
+            Button(action: player.cyclePlaybackMode) {
+                Image(systemName: playbackModeIcon)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(playbackModeTint)
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .trailing)
+            }
+            .accessibilityLabel(playbackModeLabel)
+        }
+    }
+
+    private var playbackModeIcon: String {
+        if player.shuffleEnabled { return "shuffle" }
+        switch player.repeatMode {
+        case .off: return "repeat"
+        case .all: return "repeat"
+        case .one: return "repeat.1"
+        }
+    }
+
+    private var playbackModeTint: Color {
+        (player.shuffleEnabled || player.repeatMode != .off)
+            ? Theme.accent
+            : .white.opacity(0.88)
+    }
+
+    private var playbackModeLabel: String {
+        if player.shuffleEnabled { return "随机播放" }
+        switch player.repeatMode {
+        case .off: return "顺序播放"
+        case .all: return "列表循环"
+        case .one: return "单曲循环"
+        }
+    }
+}
+
+private struct MinimalQueueSheet: View {
+    @EnvironmentObject private var player: PlayerService
+    let backdrop: ArtworkColors
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 2) {
+                    if let current = player.currentTrack {
+                        MinimalQueueSectionLabel("正在播放")
+                        MinimalQueueRow(track: current, isCurrent: true)
+
+                        if !player.upcomingTracks.isEmpty {
+                            MinimalQueueSectionLabel("即将播放")
+                                .padding(.top, 10)
+                            ForEach(
+                                Array(player.upcomingTracks.prefix(100).enumerated()),
+                                id: \.offset
+                            ) { _, track in
+                                MinimalQueueRow(track: track, isCurrent: false)
+                            }
+                        }
+                    } else {
+                        VStack(spacing: 8) {
+                            Image(systemName: "list.bullet")
+                                .font(.system(size: 28, weight: .light))
+                            Text("播放队列是空的")
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 240)
+                    }
+                }
+                .padding(10)
+            }
+            .navigationTitle("播放列表")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Text("\(player.upcomingTracks.count + (player.hasCurrentTrack ? 1 : 0)) 首")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .background(queueBackdrop)
+    }
+
+    private var queueBackdrop: some View {
+        ZStack {
+            LinearGradient(
+                colors: [backdrop.primary, backdrop.secondary],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Color.black.opacity(0.45)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+private struct MinimalQueueSectionLabel: View {
+    let text: LocalizedStringKey
+
+    init(_ text: LocalizedStringKey) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+    }
+}
+
+private struct MinimalQueueRow: View {
+    let track: Track
+    let isCurrent: Bool
+
+    @EnvironmentObject private var player: PlayerService
+
+    var body: some View {
+        Button {
+            guard !isCurrent else { return }
+            player.jumpTo(track)
+        } label: {
+            HStack(spacing: 10) {
+                CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(96), animated: false)
+                    .frame(width: 36, height: 36)
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(track.name)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(isCurrent ? Theme.accent : .primary)
+                        .lineLimit(1)
+                    Text(track.artistNames)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+
+                if isCurrent {
+                    PlayingIndicator(animating: player.isPlaying)
+                } else {
+                    Text(Formatters.duration(track.duration))
+                        .font(.system(size: 10.5).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
 
 #endif
 

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -1328,6 +1328,8 @@ private struct IOSMinimalLyricsColumn: View {
     @State private var lineCenters: [Int: CGFloat] = [:]
     @State private var isDragging = false
     @State private var suppressesAutoScroll = false
+    @State private var scrollSettleTask: Task<Void, Never>?
+    @State private var selectionTimeoutTask: Task<Void, Never>?
 
     var body: some View {
         GeometryReader { geometry in
@@ -1349,14 +1351,11 @@ private struct IOSMinimalLyricsColumn: View {
                                             return
                                         }
                                         guard selectedIndex == line.id else {
-                                            self.selectedIndex = nil
-                                            nearestIndex = nil
-                                            guard let activeIndex else { return }
-                                            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
-                                                proxy.scrollTo(activeIndex, anchor: .center)
-                                            }
+                                            returnToActiveLine(proxy: proxy)
                                             return
                                         }
+                                        selectionTimeoutTask?.cancel()
+                                        selectionTimeoutTask = nil
                                         suppressesAutoScroll = true
                                         player.seek(to: line.time) {
                                             suppressesAutoScroll = false
@@ -1390,10 +1389,15 @@ private struct IOSMinimalLyricsColumn: View {
                         .accessibilityIdentifier("syncedLyricsScroll")
                         .onPreferenceChange(MinimalLyricCentersKey.self) { centers in
                             lineCenters = centers
-                            guard isDragging else { return }
+                            guard isDragging || scrollSettleTask != nil else { return }
                             nearestIndex = nearestLine(
                                 to: geometry.size.height / 2,
                                 in: centers
+                            )
+                            guard !isDragging else { return }
+                            scheduleScrollSelection(
+                                guideY: geometry.size.height / 2,
+                                proxy: proxy
                             )
                         }
                         .onAppear {
@@ -1410,7 +1414,8 @@ private struct IOSMinimalLyricsColumn: View {
                             guard index != activeIndex else { return }
                             activeIndex = index
                             guard !suppressesAutoScroll,
-                                  !isDragging, selectedIndex == nil, let index else { return }
+                                  !isDragging, scrollSettleTask == nil,
+                                  selectedIndex == nil, let index else { return }
                             withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.38)) {
                                 proxy.scrollTo(index, anchor: .center)
                             }
@@ -1420,11 +1425,19 @@ private struct IOSMinimalLyricsColumn: View {
                             selectedIndex = nil
                             nearestIndex = nil
                             suppressesAutoScroll = false
+                            scrollSettleTask?.cancel()
+                            scrollSettleTask = nil
+                            selectionTimeoutTask?.cancel()
+                            selectionTimeoutTask = nil
                         }
                         .simultaneousGesture(
                             DragGesture()
                                 .onChanged { _ in
                                     if !isDragging {
+                                        scrollSettleTask?.cancel()
+                                        scrollSettleTask = nil
+                                        selectionTimeoutTask?.cancel()
+                                        selectionTimeoutTask = nil
                                         selectedIndex = nil
                                         isDragging = true
                                     }
@@ -1434,20 +1447,11 @@ private struct IOSMinimalLyricsColumn: View {
                                     )
                                 }
                                 .onEnded { _ in
-                                    let selection = nearestLine(
-                                        to: geometry.size.height / 2,
-                                        in: lineCenters
-                                    ) ?? nearestIndex
-                                    selectedIndex = selection
-                                    nearestIndex = selection
                                     isDragging = false
-                                    guard let selection else { return }
-                                    Task { @MainActor in
-                                        await Task.yield()
-                                        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
-                                            proxy.scrollTo(selection, anchor: .center)
-                                        }
-                                    }
+                                    scheduleScrollSelection(
+                                        guideY: geometry.size.height / 2,
+                                        proxy: proxy
+                                    )
                                 }
                         )
                         .overlay {
@@ -1474,14 +1478,19 @@ private struct IOSMinimalLyricsColumn: View {
                 }
             }
         }
+        .onDisappear {
+            scrollSettleTask?.cancel()
+            selectionTimeoutTask?.cancel()
+        }
     }
 
     @ViewBuilder
     private func selectionGuide(lyrics: ParsedLyrics) -> some View {
-        if let index = isDragging ? nearestIndex : selectedIndex,
+        let isScrolling = isDragging || scrollSettleTask != nil
+        if let index = isScrolling ? nearestIndex : selectedIndex,
            lyrics.lines.indices.contains(index) {
             HStack(spacing: 8) {
-                if isDragging {
+                if isScrolling {
                     Canvas { context, size in
                         var path = Path()
                         path.move(to: CGPoint(x: 0, y: size.height / 2))
@@ -1511,7 +1520,50 @@ private struct IOSMinimalLyricsColumn: View {
         centers.min { abs($0.value - guideY) < abs($1.value - guideY) }?.key
     }
 
+    private func scheduleScrollSelection(guideY: CGFloat, proxy: ScrollViewProxy) {
+        scrollSettleTask?.cancel()
+        // ponytail: iOS 16 has no scroll phase API; replace with onScrollPhaseChange
+        // when the deployment target reaches iOS 18.
+        scrollSettleTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled else { return }
+            let selection = nearestLine(to: guideY, in: lineCenters) ?? nearestIndex
+            selectedIndex = selection
+            nearestIndex = selection
+            scrollSettleTask = nil
+            guard let selection else { return }
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                proxy.scrollTo(selection, anchor: .center)
+            }
+            scheduleSelectionTimeout(proxy: proxy)
+        }
+    }
+
+    private func scheduleSelectionTimeout(proxy: ScrollViewProxy) {
+        selectionTimeoutTask?.cancel()
+        selectionTimeoutTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, selectedIndex != nil else { return }
+            returnToActiveLine(proxy: proxy)
+        }
+    }
+
+    private func returnToActiveLine(proxy: ScrollViewProxy) {
+        selectionTimeoutTask?.cancel()
+        selectionTimeoutTask = nil
+        selectedIndex = nil
+        nearestIndex = nil
+        guard let activeIndex else { return }
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+            proxy.scrollTo(activeIndex, anchor: .center)
+        }
+    }
+
     private func closeLyrics() {
+        scrollSettleTask?.cancel()
+        scrollSettleTask = nil
+        selectionTimeoutTask?.cancel()
+        selectionTimeoutTask = nil
         selectedIndex = nil
         nearestIndex = nil
         isDragging = false
@@ -1549,17 +1601,17 @@ private struct IOSMinimalLyricsColumn: View {
                 }
 
                 Text(line.text.isEmpty ? "♪" : line.text)
-                    .font(.system(size: 23, weight: .bold))
+                    .font(.system(size: 17, weight: .bold))
                     .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))
                     .fixedSize(horizontal: false, vertical: true)
-                    .scaleEffect(isActive ? 1.02 : 19.0 / 23.0, anchor: .leading)
+                    .scaleEffect(isActive ? 1.02 : 16.0 / 17.0, anchor: .leading)
 
                 if settings.showLyricsTranslation, let translation = line.translation {
                     Text(translation)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
                         .fixedSize(horizontal: false, vertical: true)
-                        .scaleEffect(isActive ? 1.02 : 12.0 / 14.0, anchor: .leading)
+                        .scaleEffect(isActive ? 1.02 : 12.0 / 13.0, anchor: .leading)
                 }
             }
             .multilineTextAlignment(.leading)

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -1767,6 +1767,7 @@ private struct MinimalTransportControls: View {
                     .foregroundStyle(playbackModeTint)
                     .frame(maxWidth: .infinity, minHeight: 44, alignment: .trailing)
             }
+            .buttonStyle(.plain)
             .accessibilityLabel(playbackModeLabel)
         }
     }

--- a/Sources/Kumone/Features/Player/RoutePickerButton.swift
+++ b/Sources/Kumone/Features/Player/RoutePickerButton.swift
@@ -8,12 +8,15 @@ import SwiftUI
 struct RoutePickerButton: View {
     var diameter: CGFloat = 40
     var glyphSize: CGFloat = 15
+    var request = 0
     /// White-on-glass (now-playing) vs. accent-aware (player bar).
     var tint: Color = .white.opacity(0.8)
     var background: Color = .white.opacity(0.1)
 
     var body: some View {
-        RoutePickerRepresentable(tint: PlatformColor(tint), glyphSize: glyphSize)
+        RoutePickerRepresentable(
+            tint: PlatformColor(tint), glyphSize: glyphSize, request: request
+        )
             .frame(width: diameter, height: diameter)
             .background(background, in: Circle())
             .help("AirPlay")
@@ -24,6 +27,14 @@ struct RoutePickerButton: View {
 private struct RoutePickerRepresentable: UIViewRepresentable {
     let tint: UIColor
     let glyphSize: CGFloat
+    let request: Int
+
+    final class Coordinator {
+        var request: Int
+        init(request: Int) { self.request = request }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(request: request) }
 
     func makeUIView(context: Context) -> AVRoutePickerView {
         let view = AVRoutePickerView()
@@ -36,12 +47,19 @@ private struct RoutePickerRepresentable: UIViewRepresentable {
 
     func updateUIView(_ view: AVRoutePickerView, context: Context) {
         view.tintColor = tint
+        guard request != context.coordinator.request else { return }
+        context.coordinator.request = request
+        DispatchQueue.main.async {
+            view.subviews.compactMap { $0 as? UIButton }.first?
+                .sendActions(for: .touchUpInside)
+        }
     }
 }
 #elseif os(macOS)
 private struct RoutePickerRepresentable: NSViewRepresentable {
     let tint: NSColor
     let glyphSize: CGFloat
+    let request: Int
 
     func makeNSView(context: Context) -> AVRoutePickerView {
         let view = AVRoutePickerView()


### PR DESCRIPTION
## 概述

在现有“经典模式”和“沉浸模式”之外，新增可选的“简洁模式”。

新模式采用更聚焦的封面、歌词和控制区布局，同时保留原有两种播放页的实现与默认行为。

## 效果展示

| 专辑封面 | 滚动歌词 |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/12b268f2-395d-417c-94e1-a66e4057bb6c" alt="简洁模式专辑封面" width="280"> | <img src="https://github.com/user-attachments/assets/cad93443-b1cb-4377-a286-ffa32a1705a7" alt="简洁模式滚动歌词" width="280"> |

## 主要改动

- 在设置中新增“简洁模式”选项
- 新增简洁播放页布局，不修改经典和沉浸模式
- 支持点击封面与歌词区域切换显示
- 调整滚动歌词字号与间距
- 支持拖动歌词、定位歌词并跳转播放进度
- 新增紧凑播放控制与单键播放模式切换
- 新增半屏播放队列
- 在更多菜单中提供 AirPlay 入口
- 简洁模式支持下拉关闭播放页

## 兼容性

- 默认播放页模式仍为“沉浸模式”
- 已保存的经典/沉浸模式设置保持兼容
- 未新增第三方依赖
- 未修改工程配置或数据结构

## 验证

- [x] `swift build`
- [x] iOS Simulator Debug 构建
- [x] 真机验证歌词点击、拖动和进度跳转
- [x] 真机验证 AirPlay 入口
- [x] 回归经典模式与沉浸模式