### PR TITLE
ci(release): automatically bump Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,14 @@ name: Release
 
 on:
   push:
+    branches: ["main"]
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump (e.g. 0.3.8)"
+        required: false
+        default: "0.3.8"
 
 permissions:
   contents: write
@@ -22,11 +29,18 @@ jobs:
 
       - name: Derive version
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          if [ -z "$VERSION" ] || [ "$VERSION" = "main" ]; then
+            VERSION="0.3.8"
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
 
       - name: Extract release notes from CHANGELOG.md
+        if: false
         run: |
           Scripts/release-notes.sh "$VERSION" > "$RUNNER_TEMP/notes.md"
           Scripts/release-notes.sh "$VERSION" --html > "$RUNNER_TEMP/$APP_NAME-$VERSION.html"
@@ -34,6 +48,7 @@ jobs:
           cat "$RUNNER_TEMP/notes.md"
 
       - name: Import signing certificate
+        if: false
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -52,12 +67,14 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12"
 
       - name: Build app (universal)
+        if: false
         run: |
           MARKETING_VERSION="$VERSION" BUILD_NUMBER="$BUILD_NUMBER" \
             ARCHES="arm64 x86_64" \
             Scripts/build-app.sh release
 
       - name: Codesign (Developer ID, hardened runtime)
+        if: false
         run: |
           APP=".build/app/$APP_NAME.app"
           FW="$APP/Contents/Frameworks/Sparkle.framework"
@@ -72,6 +89,7 @@ jobs:
           codesign --verify --deep --strict "$APP"
 
       - name: Notarize and staple
+        if: false
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -86,6 +104,7 @@ jobs:
           spctl -a -vv --type execute "$APP"
 
       - name: Package and generate appcast
+        if: false
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -100,15 +119,16 @@ jobs:
 
           printf '%s' "$SPARKLE_PRIVATE_KEY" | \
             "$RUNNER_TEMP/sparkle/bin/generate_appcast" \
-              --ed-key-file - \
-              --embed-release-notes \
-              --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/v$VERSION/" \
-              -o dist/appcast.xml \
-              dist
+               --ed-key-file - \
+               --embed-release-notes \
+               --download-url-prefix "https://github.com/missuo/kumone/releases/download/v$VERSION/" \
+               -o dist/appcast.xml \
+               dist
           rm -f "dist/$APP_NAME-$VERSION.html"
           cat dist/appcast.xml
 
       - name: Build unsigned iOS IPA
+        if: false
         run: |
           xcodebuild -workspace ios/KumoneIOS.xcworkspace -scheme KumoneIOS \
             -configuration Release -destination 'generic/platform=iOS' \
@@ -123,6 +143,7 @@ jobs:
           ls -la dist/
 
       - name: Create GitHub release
+        if: false
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -137,6 +158,11 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_HOMEBREW_TOKEN || secrets.HOMEBREW_GITHUB_API_TOKEN }}
         run: |
+          URL="https://github.com/missuo/kumone/releases/download/v$VERSION/$APP_NAME-$VERSION.zip"
+          if [ ! -f "dist/$APP_NAME-$VERSION.zip" ]; then
+            mkdir -p dist
+            curl -sL -o "dist/$APP_NAME-$VERSION.zip" "$URL"
+          fi
           SHA="$(shasum -a 256 "dist/$APP_NAME-$VERSION.zip" | awk '{print $1}')"
           git config --global user.email "41898282+github-actions@users.noreply.github.com"
           git config --global user.name "github-actions"
@@ -145,7 +171,7 @@ jobs:
           brew bump-cask-pr \
             --version="$VERSION" \
             --sha256="$SHA" \
-            --url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v$VERSION/$APP_NAME-$VERSION.zip" \
+            --url="$URL" \
             --no-browse \
             --no-audit \
             owo-network/brew/kumone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Bump Homebrew cask
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_HOMEBREW_TOKEN || secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_HOMEBREW_TOKEN || secrets.HOMEBREW_GITHUB_API_TOKEN || secrets.GH_TOKEN || secrets.PAT }}
         run: |
           URL="https://github.com/missuo/kumone/releases/download/v$VERSION/$APP_NAME-$VERSION.zip"
           if [ ! -f "dist/$APP_NAME-$VERSION.zip" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,6 @@ jobs:
           brew bump-cask-pr \
             --version="$VERSION" \
             --sha256="$SHA" \
-            --url="$URL" \
             --no-browse \
             --no-audit \
             owo-network/brew/kumone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,3 +132,21 @@ jobs:
             "dist/$APP_NAME-$VERSION.zip" \
             "dist/$APP_NAME-iOS-$VERSION.ipa" \
             dist/appcast.xml
+
+      - name: Bump Homebrew cask
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_HOMEBREW_TOKEN || secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        run: |
+          SHA="$(shasum -a 256 "dist/$APP_NAME-$VERSION.zip" | awk '{print $1}')"
+          git config --global user.email "41898282+github-actions@users.noreply.github.com"
+          git config --global user.name "github-actions"
+          brew update
+          brew tap owo-network/brew
+          brew bump-cask-pr \
+            --version="$VERSION" \
+            --sha256="$SHA" \
+            --url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v$VERSION/$APP_NAME-$VERSION.zip" \
+            --no-browse \
+            --no-audit \
+            owo-network/brew/kumone
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,7 @@ name: Release
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to bump (e.g. 0.3.8)"
-        required: false
-        default: "0.3.8"
 
 permissions:
   contents: write
@@ -29,18 +22,11 @@ jobs:
 
       - name: Derive version
         run: |
-          VERSION="${{ inputs.version }}"
-          if [ -z "$VERSION" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          fi
-          if [ -z "$VERSION" ] || [ "$VERSION" = "main" ]; then
-            VERSION="0.3.8"
-          fi
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
 
       - name: Extract release notes from CHANGELOG.md
-        if: false
         run: |
           Scripts/release-notes.sh "$VERSION" > "$RUNNER_TEMP/notes.md"
           Scripts/release-notes.sh "$VERSION" --html > "$RUNNER_TEMP/$APP_NAME-$VERSION.html"
@@ -48,7 +34,6 @@ jobs:
           cat "$RUNNER_TEMP/notes.md"
 
       - name: Import signing certificate
-        if: false
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -67,14 +52,12 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12"
 
       - name: Build app (universal)
-        if: false
         run: |
           MARKETING_VERSION="$VERSION" BUILD_NUMBER="$BUILD_NUMBER" \
             ARCHES="arm64 x86_64" \
             Scripts/build-app.sh release
 
       - name: Codesign (Developer ID, hardened runtime)
-        if: false
         run: |
           APP=".build/app/$APP_NAME.app"
           FW="$APP/Contents/Frameworks/Sparkle.framework"
@@ -89,7 +72,6 @@ jobs:
           codesign --verify --deep --strict "$APP"
 
       - name: Notarize and staple
-        if: false
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -104,7 +86,6 @@ jobs:
           spctl -a -vv --type execute "$APP"
 
       - name: Package and generate appcast
-        if: false
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -119,16 +100,15 @@ jobs:
 
           printf '%s' "$SPARKLE_PRIVATE_KEY" | \
             "$RUNNER_TEMP/sparkle/bin/generate_appcast" \
-               --ed-key-file - \
-               --embed-release-notes \
-               --download-url-prefix "https://github.com/missuo/kumone/releases/download/v$VERSION/" \
-               -o dist/appcast.xml \
-               dist
+              --ed-key-file - \
+              --embed-release-notes \
+              --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/v$VERSION/" \
+              -o dist/appcast.xml \
+              dist
           rm -f "dist/$APP_NAME-$VERSION.html"
           cat dist/appcast.xml
 
       - name: Build unsigned iOS IPA
-        if: false
         run: |
           xcodebuild -workspace ios/KumoneIOS.xcworkspace -scheme KumoneIOS \
             -configuration Release -destination 'generic/platform=iOS' \
@@ -143,7 +123,6 @@ jobs:
           ls -la dist/
 
       - name: Create GitHub release
-        if: false
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -158,11 +137,6 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_HOMEBREW_TOKEN || secrets.HOMEBREW_GITHUB_API_TOKEN || secrets.GH_TOKEN || secrets.PAT }}
         run: |
-          URL="https://github.com/missuo/kumone/releases/download/v$VERSION/$APP_NAME-$VERSION.zip"
-          if [ ! -f "dist/$APP_NAME-$VERSION.zip" ]; then
-            mkdir -p dist
-            curl -sL -o "dist/$APP_NAME-$VERSION.zip" "$URL"
-          fi
           SHA="$(shasum -a 256 "dist/$APP_NAME-$VERSION.zip" | awk '{print $1}')"
           git config --global user.email "41898282+github-actions@users.noreply.github.com"
           git config --global user.name "github-actions"


### PR DESCRIPTION
### Summary

Adds a step to `.github/workflows/release.yml` to automatically submit a Homebrew Cask bump PR to `owo-network/brew/kumone` whenever a new release is published.

### Changes
- Calculates the SHA-256 of `dist/$APP_NAME-$VERSION.zip` generated during the packaging step.
- Runs `brew bump-cask-pr` to automatically create a pull request in `owo-network/homebrew-brew` with the standard title format (`kumone x.y.z`).

### Required Configuration
To enable the automated cask bump workflow, please add a repository secret in `missuo/kumone`:
- **Name**: `GH_HOMEBREW_TOKEN` (or `HOMEBREW_GITHUB_API_TOKEN` / `GH_TOKEN` / `PAT`)
- **Value**: A GitHub Personal Access Token (classic) with `public_repo` (or `repo`) scope.