### PR TITLE
fix(macOS): prevent duplicate windows when reopening from Dock

### DIFF
--- a/Sources/Kumone/KumoneApp.swift
+++ b/Sources/Kumone/KumoneApp.swift
@@ -12,7 +12,7 @@ public struct KumoneApp: App {
     public init() {}
 
     public var body: some Scene {
-        WindowGroup("Kumone", id: "main") {
+        Window("Kumone", id: "main") {
             MainWindow()
                 .environmentObject(player)
                 .environmentObject(account)
@@ -140,7 +140,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }) {
             openMainWindow?()
         }
-        return true
+        // The reopen request is fully handled above. Letting AppKit handle it
+        // again can enqueue another SwiftUI scene request.
+        return false
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- make the main SwiftUI scene single-instance
- consume Dock reopen events after AppDelegate handles them
- prevent rapid Dock clicks from creating duplicate main windows

## Testing

- built and launched the debug app with `Scripts/compile_and_run.sh debug`
- manually verified closing the main window and rapidly reopening it from the Dock