### PR TITLE
feat(lyrics): 日文歌词汉字注音（振假名）；修正罗马音的促音与词典读音

### DIFF
--- a/Sources/Kumone/Core/Models/Furigana/Furigana.swift
+++ b/Sources/Kumone/Core/Models/Furigana/Furigana.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Turns a lyric line into base text plus furigana.
+///
+/// Readings come from the Japanese morphological analyser built into the OS
+/// (the one behind the Japanese input method), reached through
+/// CFStringTokenizer's Latin transcription attribute and transliterated back to
+/// hiragana. No dictionary needs to be bundled.
+enum Furigana {
+    private static let locale = Locale(identifier: "ja")
+
+    /// Segments for a line, or nil when there is nothing to annotate — a line
+    /// of pure kana, Latin or punctuation is better left to plain `Text`.
+    static func segments(for line: String) -> [RubySegment]? {
+        guard Kana.containsKanji(line) else { return nil }
+        let result = merged(annotate(line))
+        guard result.contains(where: { $0.ruby != nil }) else { return nil }
+        return result
+    }
+
+    // MARK: - Annotation
+
+    private static func annotate(_ line: String) -> [RubySegment] {
+        var result: [RubySegment] = []
+        var pending = ""
+        let characters = Array(line)
+        var index = 0
+
+        func flushPending() {
+            guard !pending.isEmpty else { return }
+            result.append(contentsOf: tokenize(pending))
+            pending = ""
+        }
+
+        while index < characters.count {
+            if let hit = ReadingOverrides.match(characters, at: index) {
+                flushPending()
+                result.append(contentsOf: RubyAligner.align(surface: hit.surface, reading: hit.reading))
+                index += hit.surface.count
+            } else {
+                pending.append(characters[index])
+                index += 1
+            }
+        }
+        flushPending()
+        return result
+    }
+
+    private static func tokenize(_ text: String) -> [RubySegment] {
+        guard Kana.containsKanji(text) else { return [RubySegment(text)] }
+
+        let cfText = text as CFString
+        let length = CFStringGetLength(cfText)
+        guard let tokenizer = CFStringTokenizerCreate(
+            kCFAllocatorDefault, cfText, CFRangeMake(0, length),
+            kCFStringTokenizerUnitWordBoundary, locale as CFLocale
+        ) else { return [RubySegment(text)] }
+        let nsText = text as NSString
+
+        var result: [RubySegment] = []
+        var consumed = 0
+
+        while CFStringTokenizerAdvanceToNextToken(tokenizer) != [] {
+            let range = CFStringTokenizerGetCurrentTokenRange(tokenizer)
+            // The tokenizer can skip characters it does not consider words.
+            if range.location > consumed {
+                let gap = nsText.substring(with: NSRange(location: consumed, length: range.location - consumed))
+                result.append(RubySegment(gap))
+            }
+            consumed = range.location + range.length
+
+            let surface = nsText.substring(with: NSRange(location: range.location, length: range.length))
+            guard Kana.containsKanji(surface) else {
+                result.append(RubySegment(surface))
+                continue
+            }
+            guard let reading = reading(from: tokenizer), Kana.isKanaOnly(reading) else {
+                result.append(RubySegment(surface))
+                continue
+            }
+            result.append(contentsOf: RubyAligner.align(surface: surface, reading: reading))
+        }
+
+        if consumed < length {
+            result.append(RubySegment(nsText.substring(from: consumed)))
+        }
+        return result
+    }
+
+    private static func reading(from tokenizer: CFStringTokenizer) -> String? {
+        guard let latin = CFStringTokenizerCopyCurrentTokenAttribute(
+            tokenizer, kCFStringTokenizerAttributeLatinTranscription
+        ) as? String, !latin.isEmpty else { return nil }
+        return latin.applyingTransform(StringTransform("Latin-Hiragana"), reverse: false)
+    }
+
+    /// Collapses runs of unannotated text so the renderer draws fewer pieces.
+    private static func merged(_ segments: [RubySegment]) -> [RubySegment] {
+        var result: [RubySegment] = []
+        for segment in segments {
+            if segment.ruby == nil, let last = result.last, last.ruby == nil {
+                result[result.count - 1] = RubySegment(last.text + segment.text)
+            } else {
+                result.append(segment)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/Kumone/Core/Models/Furigana/Kana.swift
+++ b/Sources/Kumone/Core/Models/Furigana/Kana.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Character classification and kana normalisation helpers.
+enum Kana {
+    static func isKanji(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x3005,                    // 々 iteration mark
+             0x3400...0x4DBF,           // CJK Ext A
+             0x4E00...0x9FFF,           // CJK Unified
+             0xF900...0xFAFF,           // CJK Compatibility
+             0x20000...0x2FA1F:         // CJK Ext B and beyond
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func isKana(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x3041...0x309F,           // hiragana (incl. ゝ ゞ)
+             0x30A0...0x30FF,           // katakana (incl. ー)
+             0xFF66...0xFF9F:           // halfwidth katakana
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func containsKanji(_ text: String) -> Bool {
+        text.unicodeScalars.contains(where: isKanji)
+    }
+
+    static func isKanaOnly(_ text: String) -> Bool {
+        !text.isEmpty && text.unicodeScalars.allSatisfy(isKana)
+    }
+
+    /// Katakana to hiragana, leaving everything else untouched. ー is kept as
+    /// is because it is valid in both scripts.
+    static func toHiragana(_ text: String) -> String {
+        String(String.UnicodeScalarView(text.unicodeScalars.map { scalar in
+            (0x30A1...0x30F6).contains(scalar.value)
+                ? Unicode.Scalar(scalar.value - 0x60)!
+                : scalar
+        }))
+    }
+
+    /// Compares kana ignoring the hiragana/katakana distinction, so that a
+    /// katakana surface still matches a hiragana reading.
+    static func equalIgnoringScript(_ left: some StringProtocol, _ right: some StringProtocol) -> Bool {
+        toHiragana(String(left)) == toHiragana(String(right))
+    }
+}

--- a/Sources/Kumone/Core/Models/Furigana/ReadingOverrides.swift
+++ b/Sources/Kumone/Core/Models/Furigana/ReadingOverrides.swift
@@ -36,16 +36,31 @@ enum ReadingOverrides {
     /// Longest first, so 私達 wins over 私.
     private static let sortedKeys: [String] = table.keys.sorted { $0.count > $1.count }
 
-    /// Longest match starting at `index`.
+    /// Longest match starting at `index`, and only where the word stands on
+    /// its own.
+    ///
+    /// Wedged into a longer run of kanji these are usually wrong, and the
+    /// analyser reading the whole compound is usually right: 私立 is しりつ,
+    /// not わたし plus 立; 君達 is きみたち, not きみ plus 達 read as the given
+    /// name とおる; 明日香 is あすか. The table is here for words the analyser
+    /// mis-segments, so where it has a compound to work with, it wins.
     static func match(_ characters: [Character], at index: Int) -> (surface: String, reading: String)? {
         for key in sortedKeys {
             let length = key.count
-            guard index + length <= characters.count else { continue }
-            if String(characters[index..<(index + length)]) == key, let reading = table[key] {
-                return (key, reading)
-            }
+            guard index + length <= characters.count,
+                  String(characters[index..<(index + length)]) == key,
+                  let reading = table[key],
+                  !isKanji(characters, at: index - 1),
+                  !isKanji(characters, at: index + length)
+            else { continue }
+            return (key, reading)
         }
         return nil
+    }
+
+    private static func isKanji(_ characters: [Character], at index: Int) -> Bool {
+        guard characters.indices.contains(index) else { return false }
+        return characters[index].unicodeScalars.contains(where: Kana.isKanji)
     }
 
     /// Rewrites every overridden word as its kana reading. Feeding the result

--- a/Sources/Kumone/Core/Models/Furigana/ReadingOverrides.swift
+++ b/Sources/Kumone/Core/Models/Furigana/ReadingOverrides.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Readings the system analyser gets wrong for song lyrics.
+///
+/// Two kinds of entries live here. Some words have several readings that no
+/// analyser can disambiguate, because the surface form is identical and only
+/// the register differs: 私 is わたくし in the dictionary but わたし in every
+/// song. Others are simply mis-segmented, like 一日 coming back as 一/いち plus
+/// 日/にち. Both are fixed by forcing the surface and its reading before
+/// tokenisation runs.
+enum ReadingOverrides {
+    static let table: [String: String] = [
+        // Register: the dictionary form is the formal one, lyrics use the
+        // contracted one.
+        "私": "わたし",
+        "私達": "わたしたち",
+        "私たち": "わたしたち",
+
+        // Ambiguous readings with no contextual signal.
+        "明日": "あした",
+        // 君 is くん as an honorific and きみ as "you"; lyrics mean the latter.
+        "君": "きみ",
+        "日本": "にほん",
+        // 隙 is ひま in the dictionary but すき in ordinary modern use.
+        "隙": "すき",
+
+        // Mis-segmented by the tokenizer.
+        "一日": "いちにち",
+        "一日中": "いちにちじゅう",
+        // Read as two words, which loses the rendaku: き + つき, not きづき.
+        "気付": "きづ",
+        "一昨日": "おととい",
+        "十分": "じゅうぶん",
+    ]
+
+    /// Longest first, so 私達 wins over 私.
+    private static let sortedKeys: [String] = table.keys.sorted { $0.count > $1.count }
+
+    /// Longest match starting at `index`.
+    static func match(_ characters: [Character], at index: Int) -> (surface: String, reading: String)? {
+        for key in sortedKeys {
+            let length = key.count
+            guard index + length <= characters.count else { continue }
+            if String(characters[index..<(index + length)]) == key, let reading = table[key] {
+                return (key, reading)
+            }
+        }
+        return nil
+    }
+
+    /// Rewrites every overridden word as its kana reading. Feeding the result
+    /// back to the tokenizer is what makes 私 transcribe as `watashi` rather
+    /// than the dictionary's `watakushi`.
+    static func applied(to text: String) -> String {
+        guard Kana.containsKanji(text) else { return text }
+        var result = ""
+        let characters = Array(text)
+        var index = 0
+        while index < characters.count {
+            if let hit = match(characters, at: index) {
+                result += hit.reading
+                index += hit.surface.count
+            } else {
+                result.append(characters[index])
+                index += 1
+            }
+        }
+        return result
+    }
+}

--- a/Sources/Kumone/Core/Models/Furigana/RubyAligner.swift
+++ b/Sources/Kumone/Core/Models/Furigana/RubyAligner.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// One run of base text with an optional reading rendered above it.
+struct RubySegment: Hashable {
+    let text: String
+    let ruby: String?
+
+    init(_ text: String, ruby: String? = nil) {
+        self.text = text
+        self.ruby = ruby
+    }
+}
+
+/// Splits a word into per-kanji-group segments so the reading sits only over
+/// the kanji it belongs to.
+///
+/// A morphological analyser hands back one reading for the whole word, so
+/// 繋ぎ止め/つなぎとめ would put the entire reading over 繋ぎ止 and leave a gap.
+/// Here the kana inside the surface are used as anchors: each kana run is
+/// located in the reading, and whatever precedes it belongs to the kanji run
+/// before it. That yields 繋(つな)ぎ止(と)め.
+enum RubyAligner {
+    static func align(surface: String, reading: String) -> [RubySegment] {
+        guard Kana.containsKanji(surface) else { return [RubySegment(surface)] }
+        let readingChars = Array(Kana.toHiragana(reading))
+        guard !readingChars.isEmpty else { return [RubySegment(surface)] }
+
+        var result: [RubySegment] = []
+        var cursor = 0
+        var pendingKanji: String?
+
+        for run in runs(of: surface) {
+            if run.isKanji {
+                // Two kanji runs cannot be adjacent, so this never overwrites.
+                pendingKanji = run.text
+                continue
+            }
+            // Only kana can act as an anchor; punctuation inside a word cannot.
+            guard Kana.isKanaOnly(run.text) else { return fallback(surface, reading) }
+            let needle = Array(Kana.toHiragana(run.text))
+            // A kanji run must consume at least one kana of the reading.
+            let minStart = cursor + (pendingKanji == nil ? 0 : 1)
+            guard let hit = firstIndex(of: needle, in: readingChars, from: minStart) else {
+                return fallback(surface, reading)
+            }
+            if let kanji = pendingKanji {
+                result.append(RubySegment(kanji, ruby: String(readingChars[cursor..<hit])))
+                pendingKanji = nil
+            } else if hit != cursor {
+                // Reading left over with no kanji to attach it to.
+                return fallback(surface, reading)
+            }
+            result.append(RubySegment(run.text))
+            cursor = hit + needle.count
+        }
+
+        if let kanji = pendingKanji {
+            guard cursor < readingChars.count else { return fallback(surface, reading) }
+            result.append(RubySegment(kanji, ruby: String(readingChars[cursor...])))
+            cursor = readingChars.count
+        }
+        guard cursor == readingChars.count else { return fallback(surface, reading) }
+        return result
+    }
+
+    /// When anchoring fails, keep the reading over the whole kanji span and
+    /// leave any matching kana on the base line.
+    private static func fallback(_ surface: String, _ reading: String) -> [RubySegment] {
+        let surfaceChars = Array(surface)
+        let readingChars = Array(Kana.toHiragana(reading))
+        guard let first = surfaceChars.firstIndex(where: { $0.unicodeScalars.contains(where: Kana.isKanji) }),
+              let last = surfaceChars.lastIndex(where: { $0.unicodeScalars.contains(where: Kana.isKanji) })
+        else { return [RubySegment(surface)] }
+
+        var start = 0
+        var end = readingChars.count
+        let prefix = Array(surfaceChars[..<first])
+        let suffix = Array(surfaceChars[(last + 1)...])
+        var head = ""
+        var tail = ""
+
+        if !prefix.isEmpty, prefix.count < end,
+           Kana.equalIgnoringScript(String(prefix), String(readingChars[0..<prefix.count])) {
+            start = prefix.count
+            head = String(prefix)
+        }
+        if !suffix.isEmpty, suffix.count < end - start,
+           Kana.equalIgnoringScript(String(suffix), String(readingChars[(end - suffix.count)...])) {
+            end -= suffix.count
+            tail = String(suffix)
+        }
+
+        let bodyStart = head.isEmpty ? 0 : first
+        let bodyEnd = tail.isEmpty ? surfaceChars.count : last + 1
+        let body = String(surfaceChars[bodyStart..<bodyEnd])
+        guard start < end else { return [RubySegment(surface)] }
+
+        var result: [RubySegment] = []
+        if !head.isEmpty { result.append(RubySegment(head)) }
+        result.append(RubySegment(body, ruby: String(readingChars[start..<end])))
+        if !tail.isEmpty { result.append(RubySegment(tail)) }
+        return result
+    }
+
+    private struct Run {
+        let text: String
+        let isKanji: Bool
+    }
+
+    private static func runs(of surface: String) -> [Run] {
+        var result: [Run] = []
+        var current = ""
+        var currentIsKanji: Bool?
+
+        for char in surface {
+            let isKanji = char.unicodeScalars.contains(where: Kana.isKanji)
+            if isKanji != currentIsKanji, currentIsKanji != nil {
+                result.append(Run(text: current, isKanji: currentIsKanji!))
+                current = ""
+            }
+            currentIsKanji = isKanji
+            current.append(char)
+        }
+        if let isKanji = currentIsKanji, !current.isEmpty {
+            result.append(Run(text: current, isKanji: isKanji))
+        }
+        return result
+    }
+
+    private static func firstIndex(of needle: [Character], in haystack: [Character], from start: Int) -> Int? {
+        guard !needle.isEmpty, start >= 0, start + needle.count <= haystack.count else { return nil }
+        for index in start...(haystack.count - needle.count) {
+            if Array(haystack[index..<(index + needle.count)]) == needle { return index }
+        }
+        return nil
+    }
+}

--- a/Sources/Kumone/Core/Models/LyricsParser.swift
+++ b/Sources/Kumone/Core/Models/LyricsParser.swift
@@ -6,6 +6,9 @@ struct LyricLine: Identifiable, Hashable {
     let text: String
     var translation: String?
     var romaji: String?
+    /// Base text split so each reading sits over the kanji it belongs to.
+    /// Nil when there is nothing to annotate.
+    var furigana: [RubySegment]?
 }
 
 struct ParsedLyrics: Hashable {
@@ -105,11 +108,16 @@ enum LyricsParser {
         merge(response.tlyric?.lyric, into: \.translation)
         merge(response.romalrc?.lyric, into: \.romaji)
 
-        // Romaji is only meaningful for Japanese lyrics: fill the gaps Netease
-        // left, and drop stray annotations on everything else.
+        // Readings are only meaningful for Japanese lyrics: fill the romaji
+        // gaps Netease left, annotate the kanji, and drop stray annotations on
+        // everything else. Both are done here rather than in the view so a line
+        // is analysed once per track instead of once per frame.
         if RomajiTranscriber.isJapanese(lines.map(\.text)) {
-            for i in lines.indices where lines[i].romaji == nil {
-                lines[i].romaji = RomajiTranscriber.transcribe(lines[i].text)
+            for i in lines.indices {
+                if lines[i].romaji == nil {
+                    lines[i].romaji = RomajiTranscriber.transcribe(lines[i].text)
+                }
+                lines[i].furigana = Furigana.segments(for: lines[i].text)
             }
         } else {
             for i in lines.indices {

--- a/Sources/Kumone/Core/Models/RomajiTranscriber.swift
+++ b/Sources/Kumone/Core/Models/RomajiTranscriber.swift
@@ -34,7 +34,11 @@ enum RomajiTranscriber {
         let trimmed = text.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return nil }
 
-        let source = trimmed as CFString
+        // The analyser answers with the dictionary reading, which for a
+        // handful of words is not the one anybody sings: 私 comes back as
+        // わたくし. Rewriting those to kana first is what turns `watakushi`
+        // into `watashi`.
+        let source = ReadingOverrides.applied(to: trimmed) as CFString
         let range = CFRangeMake(0, CFStringGetLength(source))
         let tokenizer = CFStringTokenizerCreate(
             kCFAllocatorDefault, source, range,
@@ -59,12 +63,37 @@ enum RomajiTranscriber {
         }
 
         guard transcribedAny else { return nil }
-        let romaji = pieces.joined(separator: " ")
-            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespaces)
+        let romaji = join(pieces)
         // Latin-only lines transcribe to themselves — don't echo the lyric.
         guard !romaji.isEmpty, !isEquivalent(romaji, trimmed) else { return nil }
         return romaji
+    }
+
+    /// The tokenizer breaks a word after its sokuon, and transcribes the
+    /// trailing っ as `~tsu`: だった comes back as `da~tsu` + `ta`. Spelling
+    /// that out as written gives `da~tsu ta`, so the marker is folded into the
+    /// syllable it belongs to by doubling that syllable's first consonant.
+    private static func join(_ pieces: [String]) -> String {
+        let sokuon = "~tsu"
+        var result: [String] = []
+        var geminateNext = false
+
+        for piece in pieces {
+            var piece = piece
+            let endsInSokuon = piece.hasSuffix(sokuon)
+            if endsInSokuon { piece.removeLast(sokuon.count) }
+
+            if geminateNext, let initial = piece.first, initial.isLetter, !result.isEmpty {
+                result[result.count - 1] += String(initial) + piece
+            } else if !piece.isEmpty {
+                result.append(piece)
+            }
+            geminateNext = endsInSokuon
+        }
+
+        return result.joined(separator: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
     }
 
     private static func isEquivalent(_ lhs: String, _ rhs: String) -> Bool {

--- a/Sources/Kumone/Core/PlatformCompatibility.swift
+++ b/Sources/Kumone/Core/PlatformCompatibility.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 public typealias PlatformImage = NSImage
 public typealias PlatformColor = NSColor
+public typealias PlatformFont = NSFont
 
 public extension Image {
     init(platformImage: PlatformImage) {
@@ -59,6 +60,7 @@ import SwiftUI
 
 public typealias PlatformImage = UIImage
 public typealias PlatformColor = UIColor
+public typealias PlatformFont = UIFont
 
 public extension Image {
     init(platformImage: PlatformImage) {

--- a/Sources/Kumone/Core/Storage/SettingsManager.swift
+++ b/Sources/Kumone/Core/Storage/SettingsManager.swift
@@ -52,6 +52,23 @@ enum AppAppearance: String, CaseIterable, Identifiable {
     }
 }
 
+/// What to show above Japanese lyrics.
+enum LyricsAnnotation: String, CaseIterable, Identifiable {
+    case off
+    case romaji
+    case furigana
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .off: return String(localized: "关闭")
+        case .romaji: return String(localized: "罗马音")
+        case .furigana: return String(localized: "汉字读音")
+        }
+    }
+}
+
 #if os(iOS)
 enum NowPlayingMode: String, CaseIterable, Identifiable {
     case classic
@@ -79,7 +96,8 @@ final class SettingsManager: ObservableObject {
         static let nowPlayingMode = "settings.nowPlayingMode"
         #endif
         static let showTranslation = "settings.showLyricsTranslation"
-        static let showRomaji = "settings.showLyricsRomaji"
+        static let showRomaji = "settings.showLyricsRomaji"  // migrated to `annotation`
+        static let annotation = "settings.lyricsAnnotation"
         static let volume = "settings.volume"
         static let fmMode = "settings.fmMode"
         static let unblock = "settings.enableUnblock"
@@ -104,9 +122,10 @@ final class SettingsManager: ObservableObject {
         didSet { UserDefaults.standard.set(showLyricsTranslation, forKey: Keys.showTranslation) }
     }
 
-    /// Romaji line above Japanese lyrics.
-    @Published var showLyricsRomaji: Bool {
-        didSet { UserDefaults.standard.set(showLyricsRomaji, forKey: Keys.showRomaji) }
+    /// Reading shown for Japanese lyrics: a romaji line above, furigana over
+    /// the kanji, or nothing.
+    @Published var lyricsAnnotation: LyricsAnnotation {
+        didSet { UserDefaults.standard.set(lyricsAnnotation.rawValue, forKey: Keys.annotation) }
     }
 
     /// Resolve gray tracks from third-party sources (UnblockNeteaseMusic-style).
@@ -127,7 +146,9 @@ final class SettingsManager: ObservableObject {
         nowPlayingMode = defaults.string(forKey: Keys.nowPlayingMode).flatMap(NowPlayingMode.init) ?? .immersive
         #endif
         showLyricsTranslation = defaults.object(forKey: Keys.showTranslation) as? Bool ?? true
-        showLyricsRomaji = defaults.object(forKey: Keys.showRomaji) as? Bool ?? false
+        // Carry over the old on/off romaji toggle for anyone who had it on.
+        lyricsAnnotation = defaults.string(forKey: Keys.annotation).flatMap(LyricsAnnotation.init)
+            ?? (defaults.bool(forKey: Keys.showRomaji) ? .romaji : .off)
         enableUnblock = defaults.object(forKey: Keys.unblock) as? Bool ?? true
         showDesktopLyrics = defaults.object(forKey: Keys.desktopLyrics) as? Bool ?? false
     }

--- a/Sources/Kumone/DesignSystem/RubyText.swift
+++ b/Sources/Kumone/DesignSystem/RubyText.swift
@@ -1,0 +1,232 @@
+import CoreText
+import SwiftUI
+
+/// Builds the Core Text attributed string that carries the ruby annotations.
+enum RubyAttributedString {
+    struct Style {
+        var size: CGFloat
+        var weight: PlatformFont.Weight
+        var color: PlatformColor
+        var rubyColor: PlatformColor
+        var rubyScale: CGFloat
+        var alignment: NSTextAlignment
+        var rounded: Bool
+
+        /// Ruby sits above the base line box, which the framesetter does not
+        /// account for, so the first line needs headroom of its own.
+        var topPadding: CGFloat { ceil(size * rubyScale * 0.9) }
+    }
+
+    static func make(_ segments: [RubySegment], style: Style) -> NSAttributedString {
+        let baseFont = font(style.size, style.weight, style.rounded)
+        let rubyFont = font(style.size * style.rubyScale, .medium, style.rounded)
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = style.alignment
+        // Room between wrapped lines for the ruby of the line below.
+        paragraph.lineHeightMultiple = 1 + style.rubyScale * 0.85
+
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: baseFont,
+            .foregroundColor: style.color,
+            .paragraphStyle: paragraph,
+        ]
+
+        let output = NSMutableAttributedString()
+        for segment in segments {
+            guard let ruby = segment.ruby, !ruby.isEmpty else {
+                output.append(NSAttributedString(string: segment.text, attributes: baseAttributes))
+                continue
+            }
+            let annotation = CTRubyAnnotationCreateWithAttributes(
+                .auto, .auto, .before, ruby as CFString,
+                [
+                    kCTFontAttributeName: rubyFont,
+                    kCTForegroundColorAttributeName: style.rubyColor,
+                ] as CFDictionary
+            )
+            var attributes = baseAttributes
+            attributes[NSAttributedString.Key(kCTRubyAnnotationAttributeName as String)] = annotation
+            output.append(NSAttributedString(string: segment.text, attributes: attributes))
+        }
+        return output
+    }
+
+    private static func font(
+        _ size: CGFloat, _ weight: PlatformFont.Weight, _ rounded: Bool
+    ) -> PlatformFont {
+        let base = PlatformFont.systemFont(ofSize: size, weight: weight)
+        guard rounded, let descriptor = base.fontDescriptor.withDesign(.rounded) else { return base }
+        #if os(macOS)
+        return PlatformFont(descriptor: descriptor, size: size) ?? base
+        #else
+        return PlatformFont(descriptor: descriptor, size: size)
+        #endif
+    }
+
+    /// Size the text needs when laid out no wider than `width`.
+    static func fittedSize(_ string: NSAttributedString, width: CGFloat) -> CGSize {
+        guard width > 0, string.length > 0 else { return .zero }
+        let framesetter = CTFramesetterCreateWithAttributedString(string)
+        return CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter, CFRangeMake(0, 0), nil,
+            CGSize(width: width, height: .greatestFiniteMagnitude), nil
+        )
+    }
+
+    /// Draws into a context whose origin is already bottom-left.
+    ///
+    /// The path is pinned to the top of `rect` and allowed to run past its
+    /// bottom, because Core Text keeps whole lines or none: a rect a point too
+    /// short for the text drops the line entirely instead of clipping it, and
+    /// an empty line is a far worse answer than a trimmed one.
+    static func draw(_ string: NSAttributedString, in rect: CGRect, context: CGContext) {
+        let framesetter = CTFramesetterCreateWithAttributedString(string)
+        let fitted = CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter, CFRangeMake(0, 0), nil,
+            CGSize(width: rect.width, height: .greatestFiniteMagnitude), nil
+        )
+        let height = max(rect.height, ceil(fitted.height))
+        let path = CGRect(x: rect.minX, y: rect.maxY - height, width: rect.width, height: height)
+        let frame = CTFramesetterCreateFrame(
+            framesetter, CFRangeMake(0, 0), CGPath(rect: path, transform: nil), nil
+        )
+        CTFrameDraw(frame, context)
+    }
+}
+
+/// Draws a lyric line with furigana over the kanji.
+///
+/// SwiftUI's `Text` has no ruby support and TextKit ignores CTRubyAnnotation,
+/// so the line is drawn with Core Text inside a `Canvas`. A `Layout` wrapper
+/// asks the framesetter how tall the line will be at the proposed width, which
+/// keeps the view participating in normal SwiftUI sizing and wrapping.
+struct RubyText: View, Animatable {
+    private var segments: [RubySegment]
+    private var size: CGFloat
+    private var weight: Font.Weight
+    private var color: Color
+    private var rubyColor: Color
+    private var rubyScale: CGFloat
+    private var alignment: NSTextAlignment
+    private var rounded: Bool
+
+    init(
+        segments: [RubySegment],
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        color: Color = .primary,
+        rubyColor: Color? = nil,
+        rubyScale: CGFloat = 0.5,
+        alignment: NSTextAlignment = .left,
+        rounded: Bool = false
+    ) {
+        self.segments = segments
+        self.size = size
+        self.weight = weight
+        self.color = color
+        self.rubyColor = rubyColor ?? color.opacity(0.75)
+        self.rubyScale = rubyScale
+        self.alignment = alignment
+        self.rounded = rounded
+    }
+
+    /// The glyphs are drawn by hand, so SwiftUI cannot interpolate them the way
+    /// it does the ones inside a `Text`. Left to itself it animates the frame
+    /// this view reports while the string jumps straight to its new size, and a
+    /// frame shorter than one line of that string draws *nothing*: Core Text
+    /// keeps whole lines or none. That is what makes a lyric blink out of
+    /// existence for the length of the highlight animation. Animating the size
+    /// instead rebuilds the string at every step, so the text and the space it
+    /// was given are never out of step.
+    var animatableData: CGFloat {
+        get { size }
+        set { size = newValue }
+    }
+
+    var body: some View {
+        let style = RubyAttributedString.Style(
+            size: size,
+            weight: weight.platform,
+            color: PlatformColor(color),
+            rubyColor: PlatformColor(rubyColor),
+            rubyScale: rubyScale,
+            alignment: alignment,
+            rounded: rounded
+        )
+        let attributed = RubyAttributedString.make(segments, style: style)
+        let inset = style.topPadding
+
+        return RubyTextLayout(attributed: attributed, topPadding: inset) {
+            Canvas(rendersAsynchronously: false) { context, canvasSize in
+                context.withCGContext { cgContext in
+                    cgContext.saveGState()
+                    cgContext.textMatrix = .identity
+                    // Core Text draws bottom-up; SwiftUI hands over a top-down context.
+                    cgContext.translateBy(x: 0, y: canvasSize.height)
+                    cgContext.scaleBy(x: 1, y: -1)
+                    RubyAttributedString.draw(
+                        attributed,
+                        in: CGRect(
+                            x: 0, y: 0,
+                            width: canvasSize.width,
+                            height: max(canvasSize.height - inset, 1)
+                        ),
+                        context: cgContext
+                    )
+                    cgContext.restoreGState()
+                }
+            }
+        }
+    }
+}
+
+/// `Layout` is `Sendable`, and `NSAttributedString` is not. The string is built
+/// once and only ever read, so carrying it in a box is enough.
+private final class AttributedBox: @unchecked Sendable {
+    let string: NSAttributedString
+    init(_ string: NSAttributedString) { self.string = string }
+}
+
+private struct RubyTextLayout: Layout {
+    private let box: AttributedBox
+    let topPadding: CGFloat
+
+    init(attributed: NSAttributedString, topPadding: CGFloat) {
+        box = AttributedBox(attributed)
+        self.topPadding = topPadding
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        // No width offered means the caller wants the natural one — under
+        // `fixedSize` the line must not stretch to some arbitrary default.
+        guard let proposed = proposal.width, proposed.isFinite, proposed > 0 else {
+            let fitted = RubyAttributedString.fittedSize(box.string, width: .greatestFiniteMagnitude)
+            return CGSize(width: ceil(fitted.width), height: ceil(fitted.height) + topPadding)
+        }
+        let fitted = RubyAttributedString.fittedSize(box.string, width: proposed)
+        return CGSize(width: proposed, height: ceil(fitted.height) + topPadding)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        for subview in subviews {
+            subview.place(at: bounds.origin, proposal: ProposedViewSize(bounds.size))
+        }
+    }
+}
+
+private extension Font.Weight {
+    var platform: PlatformFont.Weight {
+        switch self {
+        case .ultraLight: return .ultraLight
+        case .thin: return .thin
+        case .light: return .light
+        case .medium: return .medium
+        case .semibold: return .semibold
+        case .bold: return .bold
+        case .heavy: return .heavy
+        case .black: return .black
+        default: return .regular
+        }
+    }
+}

--- a/Sources/Kumone/DesignSystem/RubyText.swift
+++ b/Sources/Kumone/DesignSystem/RubyText.swift
@@ -40,15 +40,19 @@ enum RubyAttributedString {
         for segment in segments {
             let start = cursor
             cursor += segment.text.count
+            let span = alphas.map { a in (start..<cursor).map { $0 < a.count ? a[$0] : 1 } }
+
             guard let ruby = segment.ruby, !ruby.isEmpty else {
-                output.append(NSAttributedString(string: segment.text, attributes: baseAttributes))
+                output.append(tinted(segment.text, baseAttributes, span, style.color))
                 continue
             }
-            var rubyColor = style.rubyColor
-            if let alphas {
-                let over = (start..<cursor).compactMap { $0 < alphas.count ? alphas[$0] : nil }
-                rubyColor = rubyColor.withAlphaComponent(rubyColor.cgColor.alpha * CGFloat(over.min() ?? 1))
-            }
+            // An annotated run has to stay a *single* attribute run. Core Text
+            // draws the annotation once per run, so colouring 気 and 分
+            // separately as the wipe passes between them repeats きぶん over
+            // each of them and prises the pair apart. The run fades as a whole
+            // instead, on the mean of the characters it covers.
+            let level = span.map { $0.reduce(0, +) / Double(max($0.count, 1)) } ?? 1
+
             // `.auto` alignment spreads the reading evenly across its base,
             // which at lyric sizes reads as loose tracking: あなた over 貴方
             // comes out あ な た. Centring keeps it together.
@@ -63,29 +67,35 @@ enum RubyAttributedString {
                 .center, .auto, .before, ruby as CFString,
                 [
                     kCTFontAttributeName: rubyFont,
-                    kCTForegroundColorAttributeName: rubyColor,
+                    kCTForegroundColorAttributeName: style.rubyColor.faded(to: level),
                 ] as CFDictionary
             )
             var attributes = baseAttributes
+            attributes[.foregroundColor] = style.color.faded(to: level)
             attributes[NSAttributedString.Key(kCTRubyAnnotationAttributeName as String)] = annotation
             output.append(NSAttributedString(string: segment.text, attributes: attributes))
         }
-
-        if let alphas {
-            var location = 0
-            for (index, character) in Array(output.string).enumerated() {
-                let length = (String(character) as NSString).length
-                if index < alphas.count {
-                    output.addAttribute(
-                        .foregroundColor,
-                        value: style.color.withAlphaComponent(style.color.cgColor.alpha * CGFloat(alphas[index])),
-                        range: NSRange(location: location, length: length)
-                    )
-                }
-                location += length
-            }
-        }
         return output
+    }
+
+    /// Unannotated text can be coloured character by character; splitting the
+    /// run there costs nothing.
+    private static func tinted(
+        _ text: String, _ attributes: [NSAttributedString.Key: Any],
+        _ alphas: [Double]?, _ color: PlatformColor
+    ) -> NSAttributedString {
+        let piece = NSMutableAttributedString(string: text, attributes: attributes)
+        guard let alphas else { return piece }
+        var location = 0
+        for (index, character) in text.enumerated() {
+            let length = (String(character) as NSString).length
+            if index < alphas.count {
+                piece.addAttribute(.foregroundColor, value: color.faded(to: alphas[index]),
+                                   range: NSRange(location: location, length: length))
+            }
+            location += length
+        }
+        return piece
     }
 
     private static func font(
@@ -260,5 +270,11 @@ private extension Font.Weight {
         case .black: return .black
         default: return .regular
         }
+    }
+}
+
+private extension PlatformColor {
+    func faded(to level: Double) -> PlatformColor {
+        withAlphaComponent(cgColor.alpha * CGFloat(level))
     }
 }

--- a/Sources/Kumone/DesignSystem/RubyText.swift
+++ b/Sources/Kumone/DesignSystem/RubyText.swift
@@ -38,8 +38,18 @@ enum RubyAttributedString {
                 output.append(NSAttributedString(string: segment.text, attributes: baseAttributes))
                 continue
             }
+            // `.auto` alignment spreads the reading evenly across its base,
+            // which at lyric sizes reads as loose tracking: あなた over 貴方
+            // comes out あ な た. Centring keeps it together.
+            //
+            // A reading too wide for its base still has to go somewhere, and
+            // overhanging the neighbouring kana is what Japanese typesetting
+            // does. Scaling it down to fit instead would keep every line at its
+            // unannotated width, but the reading size would then swing with the
+            // ratio: なみだ over 涙 would render two thirds the size of あじ
+            // over 味, in the same line. Ruby is set at one size.
             let annotation = CTRubyAnnotationCreateWithAttributes(
-                .auto, .auto, .before, ruby as CFString,
+                .center, .auto, .before, ruby as CFString,
                 [
                     kCTFontAttributeName: rubyFont,
                     kCTForegroundColorAttributeName: style.rubyColor,

--- a/Sources/Kumone/DesignSystem/RubyText.swift
+++ b/Sources/Kumone/DesignSystem/RubyText.swift
@@ -11,20 +11,18 @@ enum RubyAttributedString {
         var rubyScale: CGFloat
         var alignment: NSTextAlignment
         var rounded: Bool
-
-        /// Ruby sits above the base line box, which the framesetter does not
-        /// account for, so the first line needs headroom of its own.
-        var topPadding: CGFloat { ceil(size * rubyScale * 0.9) }
     }
 
     static func make(_ segments: [RubySegment], style: Style) -> NSAttributedString {
         let baseFont = font(style.size, style.weight, style.rounded)
         let rubyFont = font(style.size * style.rubyScale, .medium, style.rounded)
 
+        // The framesetter measures the ruby: an annotated line reports a
+        // taller box than the same text without it, and a wrapped line leaves
+        // room for the ruby of the line below. Adding headroom on top of that
+        // just leaves a dead band above the text.
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = style.alignment
-        // Room between wrapped lines for the ruby of the line below.
-        paragraph.lineHeightMultiple = 1 + style.rubyScale * 0.85
 
         let baseAttributes: [NSAttributedString.Key: Any] = [
             .font: baseFont,
@@ -165,9 +163,8 @@ struct RubyText: View, Animatable {
             rounded: rounded
         )
         let attributed = RubyAttributedString.make(segments, style: style)
-        let inset = style.topPadding
 
-        return RubyTextLayout(attributed: attributed, topPadding: inset) {
+        return RubyTextLayout(attributed: attributed) {
             Canvas(rendersAsynchronously: false) { context, canvasSize in
                 context.withCGContext { cgContext in
                     cgContext.saveGState()
@@ -177,11 +174,7 @@ struct RubyText: View, Animatable {
                     cgContext.scaleBy(x: 1, y: -1)
                     RubyAttributedString.draw(
                         attributed,
-                        in: CGRect(
-                            x: 0, y: 0,
-                            width: canvasSize.width,
-                            height: max(canvasSize.height - inset, 1)
-                        ),
+                        in: CGRect(origin: .zero, size: canvasSize),
                         context: cgContext
                     )
                     cgContext.restoreGState()
@@ -200,11 +193,9 @@ private final class AttributedBox: @unchecked Sendable {
 
 private struct RubyTextLayout: Layout {
     private let box: AttributedBox
-    let topPadding: CGFloat
 
-    init(attributed: NSAttributedString, topPadding: CGFloat) {
+    init(attributed: NSAttributedString) {
         box = AttributedBox(attributed)
-        self.topPadding = topPadding
     }
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
@@ -212,10 +203,10 @@ private struct RubyTextLayout: Layout {
         // `fixedSize` the line must not stretch to some arbitrary default.
         guard let proposed = proposal.width, proposed.isFinite, proposed > 0 else {
             let fitted = RubyAttributedString.fittedSize(box.string, width: .greatestFiniteMagnitude)
-            return CGSize(width: ceil(fitted.width), height: ceil(fitted.height) + topPadding)
+            return CGSize(width: ceil(fitted.width), height: ceil(fitted.height))
         }
         let fitted = RubyAttributedString.fittedSize(box.string, width: proposed)
-        return CGSize(width: proposed, height: ceil(fitted.height) + topPadding)
+        return CGSize(width: proposed, height: ceil(fitted.height))
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {

--- a/Sources/Kumone/Features/Pages/SettingsView.swift
+++ b/Sources/Kumone/Features/Pages/SettingsView.swift
@@ -36,8 +36,12 @@ struct SettingsView: View {
                 }
                 #endif
                 Toggle("显示歌词翻译", isOn: $settings.showLyricsTranslation)
-                Toggle("显示日文歌词罗马音", isOn: $settings.showLyricsRomaji)
-                Text("日文歌词上方显示罗马音，缺少官方罗马音时自动生成读音")
+                Picker("日文歌词读音", selection: $settings.lyricsAnnotation) {
+                    ForEach(LyricsAnnotation.allCases) { annotation in
+                        Text(annotation.displayName).tag(annotation)
+                    }
+                }
+                Text("罗马音在歌词上方另起一行，汉字读音把假名标在汉字正上方；缺少官方罗马音时自动生成读音")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 #if os(macOS)

--- a/Sources/Kumone/Features/Player/DesktopLyrics.swift
+++ b/Sources/Kumone/Features/Player/DesktopLyrics.swift
@@ -134,11 +134,23 @@ private struct DesktopLyricsBox: View {
                 // The box itself stays put; only the text crossfades and the
                 // capsule width eases to the new line's size.
                 VStack(spacing: 5) {
-                    Text(line.text)
-                        .font(.system(size: 26, weight: .bold, design: .rounded))
-                        .foregroundStyle(.white)
-                        .shadow(color: .black.opacity(0.5), radius: 3, y: 1)
-                        .contentTransition(.opacity)
+                    if settings.lyricsAnnotation == .romaji, let romaji = line.romaji {
+                        Text(romaji)
+                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.78))
+                            .shadow(color: .black.opacity(0.5), radius: 2, y: 1)
+                            .contentTransition(.opacity)
+                    }
+                    LyricText(
+                        line: line,
+                        size: 26,
+                        weight: .bold,
+                        color: .white,
+                        alignment: .center,
+                        rounded: true
+                    )
+                    .shadow(color: .black.opacity(0.5), radius: 3, y: 1)
+                    .contentTransition(.opacity)
                     if settings.showLyricsTranslation, let translation = line.translation {
                         Text(translation)
                             .font(.system(size: 16, weight: .semibold, design: .rounded))

--- a/Sources/Kumone/Features/Player/LyricText.swift
+++ b/Sources/Kumone/Features/Player/LyricText.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// The lyric itself, with furigana over the kanji when the reader asked for it
+/// and the line has kanji worth annotating.
+///
+/// Every other case falls through to a plain `Text`, so lyrics that are not
+/// Japanese, and the two annotation modes that are not furigana, keep exactly
+/// the rendering they had.
+struct LyricText: View {
+    let line: LyricLine
+    let size: CGFloat
+    var weight: Font.Weight = .regular
+    var color: Color = .primary
+    var alignment: NSTextAlignment = .left
+    var rounded: Bool = false
+
+    @EnvironmentObject private var settings: SettingsManager
+
+    var body: some View {
+        if settings.lyricsAnnotation == .furigana, let furigana = line.furigana {
+            RubyText(
+                segments: furigana,
+                size: size,
+                weight: weight,
+                color: color,
+                rubyColor: color.opacity(0.72),
+                alignment: alignment,
+                rounded: rounded
+            )
+        } else {
+            Text(line.text.isEmpty ? "♪" : line.text)
+                .font(.system(size: size, weight: weight, design: rounded ? .rounded : .default))
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Sources/Kumone/Features/Player/LyricText.swift
+++ b/Sources/Kumone/Features/Player/LyricText.swift
@@ -30,6 +30,10 @@ struct LyricText: View {
                 rounded: rounded,
                 alphas: alphas
             )
+            // The line is glyphs in a `Canvas`, which carries no text for
+            // VoiceOver to read. Stand in the plain lyric; the readings are a
+            // visual aid and would only clutter it spoken.
+            .accessibilityRepresentation { Text(line.text.isEmpty ? "♪" : line.text) }
         } else if let alphas, !alphas.isEmpty {
             wiped(alphas)
                 .font(.system(size: size, weight: weight, design: rounded ? .rounded : .default))

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -599,14 +599,17 @@ struct NowPlayingView: View {
             player.seek(to: line.time)
         } label: {
             VStack(alignment: .leading, spacing: 5) {
-                if settings.showLyricsRomaji, let romaji = line.romaji {
+                if settings.lyricsAnnotation == .romaji, let romaji = line.romaji {
                     Text(romaji)
                         .font(.system(size: isActive ? 15 : 13, weight: .medium))
                         .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
                 }
-                Text(line.text.isEmpty ? "♪" : line.text)
-                    .font(.system(size: isActive ? 26 : 20, weight: isActive ? .bold : .semibold))
-                    .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))
+                LyricText(
+                    line: line,
+                    size: isActive ? 26 : 20,
+                    weight: isActive ? .bold : .semibold,
+                    color: .white.opacity(isActive ? 1 : 0.45)
+                )
                 if settings.showLyricsTranslation, let translation = line.translation {
                     Text(translation)
                         .font(.system(size: isActive ? 16 : 14, weight: .medium))
@@ -720,15 +723,18 @@ private struct IOSImmersiveLyricsColumn: View {
             player.seek(to: line.time)
         } label: {
             VStack(alignment: .leading, spacing: 5) {
-                if settings.showLyricsRomaji, let romaji = line.romaji {
+                if settings.lyricsAnnotation == .romaji, let romaji = line.romaji {
                     Text(romaji)
                         .font(.system(size: isActive ? 15 : 13, weight: .medium))
                         .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
                 }
 
-                Text(line.text.isEmpty ? "♪" : line.text)
-                    .font(.system(size: 27, weight: isActive ? .bold : .semibold))
-                    .foregroundStyle(.white.opacity(isActive ? 1 : 0.45))
+                LyricText(
+                    line: line,
+                    size: 27,
+                    weight: isActive ? .bold : .semibold,
+                    color: .white.opacity(isActive ? 1 : 0.45)
+                )
 
                 if settings.showLyricsTranslation, let translation = line.translation {
                     Text(translation)

--- a/Sources/Kumone/Features/Player/Panels.swift
+++ b/Sources/Kumone/Features/Player/Panels.swift
@@ -114,14 +114,19 @@ struct LyricsPanel: View {
             player.seek(to: line.time)
         } label: {
             VStack(alignment: .leading, spacing: 3) {
-                if settings.showLyricsRomaji, let romaji = line.romaji {
+                if settings.lyricsAnnotation == .romaji, let romaji = line.romaji {
                     Text(romaji)
                         .font(.system(size: isActive ? 12 : 11))
                         .foregroundStyle(isActive ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
                 }
-                Text(line.text.isEmpty ? "♪" : line.text)
-                    .font(.system(size: isActive ? 16 : 14, weight: isActive ? .bold : .medium))
-                    .foregroundStyle(isActive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                LyricText(
+                    line: line,
+                    size: isActive ? 16 : 14,
+                    weight: isActive ? .bold : .medium,
+                    // Core Text needs a resolved colour, so the hierarchical
+                    // styles the other rows use are spelled out here.
+                    color: isActive ? .primary : .secondary
+                )
                 if settings.showLyricsTranslation, let translation = line.translation {
                     Text(translation)
                         .font(.system(size: isActive ? 13 : 12))

--- a/Sources/Kumone/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kumone/Resources/en.lproj/Localizable.strings
@@ -206,6 +206,11 @@
 "浅色" = "Light";
 "深色" = "Dark";
 "显示歌词翻译" = "Show Lyrics Translation";
+"日文歌词读音" = "Japanese Lyrics Reading";
+"关闭" = "Off";
+"罗马音" = "Romaji";
+"汉字读音" = "Furigana";
+"罗马音在歌词上方另起一行，汉字读音把假名标在汉字正上方；缺少官方罗马音时自动生成读音" = "Romaji goes on its own line above the lyric; furigana sits directly over the kanji. Readings are generated on device when NetEase ships no official romaji";
 "桌面歌词" = "Desktop Lyrics";
 "在屏幕上悬浮显示当前歌词，可拖动调整位置" = "Float the current lyric line on screen; drag to reposition";
 "存储" = "Storage";


### PR DESCRIPTION
Follow up on #25. 为日文歌词添加振假名，假名直接标在每个汉字正上方，原有的罗马音一档完整保留。  

<img width="2778" height="1608" alt="2026-08-28 17 08 09@2x" src="https://github.com/user-attachments/assets/e39e7d36-b2df-4a59-b763-cdd201b44e32" />

    
<img width="259" height="492" alt="2026-08-28 15 23 04@2x" src="https://github.com/user-attachments/assets/a1117e1c-742e-4373-9630-2747eccd827a" />

## 实现

### 读音来源

与 #25 同源：系统自带的日语形态分析器，经 `CFStringTokenizer` 的 `kCFStringTokenizerAttributeLatinTranscription`（locale `ja`）取得后用 `Latin-Hiragana` 转回平假名。离线、零依赖、不打包词典。

### 逐汉字对齐

分析器只给**整个词**一个读音，直接标注会把整串读音压在词首的汉字连续段上、后面留空：`繋ぎ止め / つなぎとめ` 会变成 `繋ぎ止(つなぎとめ)め`。

`RubyAligner` 用词内的假名当锚点切分：每段假名在读音里定位，它之前的部分归前一段汉字，得到 `繋(つな)ぎ止(と)め`。锚定失败时退回「整段汉字一个读音」，不会产出错位结果。

### 读音覆盖表

分析器给的是词典读音，有几个词没人这么唱：`私` 回来是 `わたくし`，`明日` 是 `あす`，`君` 在歌词里几乎都是 `きみ` 而不是敬称的 `くん`。另有一类是分析器切错，比如 `一日` 被切成 `一/いち` + `日/にち`。这两类在分词前先改写成假名。

覆盖**只在词独立成词时**生效：匹配的前后紧邻汉字时不套用，交回分析器。因为这张表是为分析器切错的词准备的，而它拿到整个复合词时切分和读音都是对的：

| 输入 | 只做子串匹配 | 现在 |
|---|---|---|
| 私立学校 | 私(わたし)立(りっ)学校(がっこう) | 私立(しりつ)学校(がっこう) |
| 君達 | 君(きみ)達(とおる) | 君(きみ)達(たち) |
| 明日香 | 明日(あした)香(こう) | 明日香(あすか) |
| 五十分 | 五(ご)十分(じゅうぶん) | 五十(ごじゅう)分(ふん) |

`君達` 那一行里 `達` 被当成人名 `とおる` 读了。

### 渲染

SwiftUI 的 `Text` 不支持 ruby，TextKit 也会忽略 `CTRubyAnnotation`，所以整行改用 Core Text 画在 `Canvas` 里，外面套一层 `Layout` 向排版器问高度，让它照常参与 SwiftUI 的换行和布局。三个细节：

- **字号可动画**。`RubyText` 对字号实现了 `Animatable`。字号跳变而外框在动画时，Core Text 会因为高度不够而**整行不画**（它保留整行或不保留），歌词会在高亮动画期间凭空消失。
- **注音居中而非均分**。Core Text 默认的 `.auto` 会把读音均分铺满底字，在歌词字号下读起来像字距坏掉：`あなた` 标在 `貴方` 上会摊成 `あ な た`。居中后行宽不变。
- **不额外留白**。排版器本身就把注音计入行高（同一行无注音 31pt、带注音 44pt），再叠 `lineHeightMultiple` 和 `topPadding` 会在文字上方留下一条死区，26pt 的行量出来框高 74pt 而字只有 38pt。两层都去掉后是 44pt，上下各 3pt。

## 与逐字歌词共存

`LyricMainText` 保留它的职责（跟播放时钟推进擦除），但不再自己拼 `Text`，而是把行交给 `LyricText` 并把**逐字透明度**传下去；要不要注音仍由 `LyricText` 决定，擦除两边都生效。注音模式下透明度进的是 Core Text 属性串，读音跟着它底下最暗的那个字，所以 `涙` 唱到时 `なみだ` 亮、`味` 还没唱到时 `あじ` 仍是暗的。

两个坑：

- **带注音的 run 必须整体上色**。Core Text 按 attribute run 绘制注音，一个 run 画一次。逐字上色会在擦除走到 `気分` 中间时把 run 劈成两个，两个 run 各自带着同一个 `CTRubyAnnotation`，于是 `きぶん` 被画两遍、两个字被撑开成 `気 分`。现在带注音的 run 按它覆盖字符的平均透明度整体淡入；没有注音的部分照旧逐字。
- **透明度要对齐到 `line.text`**。`parseYRC` 里 `line.text` 是把 words 拼起来**再 trim** 的，不重新对齐的话，行首有空格的歌词会整整错开一个字。

`font: Font` 相应改成 `size` + `weight`，排版器需要具体数值而 `Font` 拿不回来。三个调用点原本都是字面量 `.system(size:weight:)`，机械替换。

## 设置与 UI

「显示日文歌词罗马音」开关换成「日文歌词读音」三选：**关闭 / 罗马音 / 汉字读音**。原来开着罗马音的用户读旧键一次自动落到「罗马音」。en 本地化补齐（#25 当时漏了这一组）。 


<img width="668" height="235" alt="2026-08-28 17 00 34@2x" src="https://github.com/user-attachments/assets/d0fd8abd-3831-4b99-9bb6-5902047e276b" />


接入沉浸播放页（macOS 与 iOS 两份）、侧边歌词栏、macOS 桌面歌词。不是日文的歌词、以及另外两档，走的还是原来的 `Text`，渲染没有任何变化。

桌面歌词那个胶囊是 `fixedSize`，所以给 `Layout` 补了一条：没拿到宽度时量自然宽度，否则会固定撑到 400pt。

无障碍：注音模式下整行是画进 `Canvas` 的像素，不产生 accessibility 文本节点，VoiceOver 会读不到歌词（无标签按钮，或只剩下面那行翻译）。用 `.accessibilityRepresentation` 给它一个 `Text(line.text)` 替身；注音不进去，它是视觉辅助，念出来只会干扰。

## 顺带修正的罗马音

改的过程中发现现有罗马音有两个问题，各自一个 commit。

**促音**。分词器把促音单独切出来转写成 `~tsu`，空格拼接后直接漏进结果。促音在歌词里极常见：

| 原文 | 改前 | 改后 |
|---|---|---|
| 好きだった人 | `suki da~tsu ta hito` | `suki datta hito` |
| 行ってしまった | `i~tsu te shima~tsu ta` | `itte shimatta` |
| ちょっと待って | `cho~tsu to ma~tsu te` | `chotto matte` |

现在把这个标记折进后一个音节，让它的首辅音成对。

**词典读音**。上面那张覆盖表同时作用于罗马音：`watakushi → watashi`、`asu → ashita`、`kun → kimi`、`nippon → nihon`。逐行对过 baseline，只有变好的，没有变差的。

## 取舍与已知限制

- 读音是本地生成的，人名与特殊读法仍可能出错，属于可接受的降级（与 #25 同）。
- 覆盖表加了边界判定之后，有两个词退回正式语体：`私自身 → わたくしじしん`、`日本語 → にっぽんご`。都还是正确的词，而表格里那几个是读错字。
- 注音比底字宽时仍会溢出到旁边（日文排版本来就这么处理）。缩放注音去凑宽度会让字号随比例摇摆，同一行里 `なみだ` 会比 `あじ` 小三分之一，所以没有采用。行首那个词注音过宽时，整行会往右缩进 3 到 4pt。
- 换行歌词的行间比之前紧（去掉了那个 1.425 倍行高）。桌面歌词是单行不受影响。
- 逐字歌词覆盖率本身不高。抽样：热歌榜 6/30、日语榜 3/10、新歌榜 0/30 有 `yrc`。这与本 PR 无关，但会影响「同时开两项」的实测机会。
- 注音按**字身框**对齐，不按墨迹，这也正是日文排版的做法（モノルビ 对的是全角字身格）。个别瘦字形因此看着略偏，最明显的是 `く`：它的墨迹只占字身框的一半多（20.3pt / 37.7pt），右侧留白很大，于是 `僕` 上的 `ぼく` 视觉上偏左约 1.2pt（歌词 26pt 字号下）。作为对照，底字 `僕` 自身的墨迹偏心只有 +0.1pt，`きみ` 与 `きぶん` 是 +1.8pt，所以只有这一处看得出来。`CTRubyAnnotation` 没有位移参数，要按墨迹视觉居中只能放弃它、自己画注音，连带丢掉换行与溢出处理，代价远大于收益。


## 验证

- macOS `swift build` 通过；`Scripts/build-app.sh` 打包运行正常。
- iOS `xcodebuild -scheme KumoneIOS -destination 'generic/platform=iOS'` 通过。这一步是必要的：`#if os(iOS)` 里的简洁播放页有一处旧设置引用，macOS 构建看不到。
- iPhone 17 Pro / iOS 26.0 模拟器实测：设置三档切换、沉浸播放页四层显示、逐字擦除与注音同时工作。
- Core Text 渲染逐项离屏出图核对：注音对齐、换行、`fixedSize` 胶囊、擦除穿过多字汉字词的每一帧。
- 分支已合并 `upstream/main`（0.3.12），冲突五处全部人工解决。
