### PR TITLE
fix(ios): playlist card alignment, skeleton headers, FM layout, and player clearance

### DIFF
--- a/Sources/Kumone/DesignSystem/Cards.swift
+++ b/Sources/Kumone/DesignSystem/Cards.swift
@@ -41,6 +41,7 @@ struct CoverCard: View {
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                     .foregroundStyle(.primary)
+                    .frame(maxWidth: size, minHeight: 36, alignment: .topLeading)
                 if let subtitle, !subtitle.isEmpty {
                     Text(subtitle)
                         .font(.system(size: 11))

--- a/Sources/Kumone/DesignSystem/Theme.swift
+++ b/Sources/Kumone/DesignSystem/Theme.swift
@@ -34,6 +34,33 @@ enum Theme {
         static let playerBarBottomMargin: CGFloat = 10
         /// Bottom inset pages need so scrolled content clears the floating bar.
         static var playerChromeClearance: CGFloat { playerBarHeight + playerBarBottomMargin }
+        /// Extra breathing margin for scrollable content clearing chrome.
+        static let scrollBreathingMargin: CGFloat = 8
+
+        #if os(iOS)
+        enum FloatingChrome {
+            /// Total height of GlassTabBar: 56pt content + 2 * 4pt inset.
+            static let tabBarHeight: CGFloat = 64
+            /// Total height of legacy mini player bar: 44pt button + 2 * 4pt vertical padding.
+            static let miniPlayerHeight: CGFloat = 52
+            /// Spacing between mini player and tab bar in customTabInterface.
+            static let barSpacing: CGFloat = 8
+            /// Bottom padding under the tab bar.
+            static let bottomMargin: CGFloat = 6
+            /// Breathing margin ensuring content clears above the floating bars.
+            static let extraPadding: CGFloat = 12
+
+            /// Clearance needed when only the tab bar is visible.
+            static var tabBarClearance: CGFloat {
+                tabBarHeight + bottomMargin + extraPadding
+            }
+
+            /// Clearance needed when both mini player and tab bar are visible.
+            static var fullChromeClearance: CGFloat {
+                miniPlayerHeight + barSpacing + tabBarHeight + bottomMargin + extraPadding
+            }
+        }
+        #endif
         static let minWindowWidth: CGFloat = 1020
         /// Width the split view's divider occupies between the two columns.
         static let splitDividerWidth: CGFloat = 8

--- a/Sources/Kumone/Features/Detail/AlbumDetailView.swift
+++ b/Sources/Kumone/Features/Detail/AlbumDetailView.swift
@@ -318,18 +318,18 @@ struct AlbumDetailView: View {
     }
 
     private var loadingHeader: some View {
-        HStack(spacing: 24) {
-            RoundedRectangle(cornerRadius: Theme.Radius.large, style: .continuous)
-                .fill(.primary.opacity(0.05))
+        HStack(alignment: .top, spacing: isCompact ? 14 : 24) {
+            SkeletonView(cornerRadius: isCompact ? Theme.Radius.standard : Theme.Radius.large)
                 .frame(width: isCompact ? 120 : 200, height: isCompact ? 120 : 200)
+
             VStack(alignment: .leading, spacing: 10) {
-                RoundedRectangle(cornerRadius: 4).fill(.primary.opacity(0.08)).frame(width: 60, height: 14)
-                RoundedRectangle(cornerRadius: 6).fill(.primary.opacity(0.1)).frame(width: 180, height: 24)
-                RoundedRectangle(cornerRadius: 4).fill(.primary.opacity(0.06)).frame(width: 120, height: 14)
+                SkeletonView(cornerRadius: 4).frame(width: 80, height: 14)
+                SkeletonView(cornerRadius: 4).frame(maxWidth: isCompact ? 160 : 200, minHeight: 14, maxHeight: 14)
+                SkeletonView(cornerRadius: 4).frame(width: 120, height: 14)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, isCompact ? 16 : Theme.Layout.contentInset)
-        .padding(.top, 16)
+        .padding(.top, isCompact ? 12 : 16)
     }
 }

--- a/Sources/Kumone/Features/Detail/ArtistDetailView.swift
+++ b/Sources/Kumone/Features/Detail/ArtistDetailView.swift
@@ -297,17 +297,18 @@ struct ArtistDetailView: View {
     }
 
     private var loadingHeader: some View {
-        HStack(spacing: 24) {
-            Circle()
-                .fill(.primary.opacity(0.05))
+        HStack(alignment: .center, spacing: isCompact ? 14 : 24) {
+            SkeletonView(cornerRadius: isCompact ? 50 : 90)
+                .clipShape(Circle())
                 .frame(width: isCompact ? 100 : 180, height: isCompact ? 100 : 180)
+
             VStack(alignment: .leading, spacing: 10) {
-                RoundedRectangle(cornerRadius: 6).fill(.primary.opacity(0.1)).frame(width: 160, height: 26)
-                RoundedRectangle(cornerRadius: 4).fill(.primary.opacity(0.06)).frame(width: 110, height: 14)
+                SkeletonView(cornerRadius: 4).frame(maxWidth: isCompact ? 150 : 180, minHeight: 14, maxHeight: 14)
+                SkeletonView(cornerRadius: 4).frame(width: 100, height: 14)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, isCompact ? 16 : Theme.Layout.contentInset)
-        .padding(.top, 16)
+        .padding(.top, isCompact ? 12 : 16)
     }
 }

--- a/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
+++ b/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
@@ -421,18 +421,18 @@ struct PlaylistDetailView: View {
     }
 
     private var loadingHeader: some View {
-        HStack(spacing: 24) {
-            RoundedRectangle(cornerRadius: Theme.Radius.large, style: .continuous)
-                .fill(.primary.opacity(0.05))
+        HStack(alignment: .top, spacing: isCompact ? 14 : 24) {
+            SkeletonView(cornerRadius: isCompact ? Theme.Radius.standard : Theme.Radius.large)
                 .frame(width: isCompact ? 120 : 200, height: isCompact ? 120 : 200)
+
             VStack(alignment: .leading, spacing: 10) {
-                RoundedRectangle(cornerRadius: 4).fill(.primary.opacity(0.08)).frame(width: 80, height: 14)
-                RoundedRectangle(cornerRadius: 6).fill(.primary.opacity(0.1)).frame(width: 220, height: 24)
-                RoundedRectangle(cornerRadius: 4).fill(.primary.opacity(0.06)).frame(width: 140, height: 12)
+                SkeletonView(cornerRadius: 4).frame(width: 80, height: 14)
+                SkeletonView(cornerRadius: 4).frame(maxWidth: isCompact ? 160 : 220, minHeight: 14, maxHeight: 14)
+                SkeletonView(cornerRadius: 4).frame(width: 120, height: 14)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, isCompact ? 16 : Theme.Layout.contentInset)
-        .padding(.top, 16)
+        .padding(.top, isCompact ? 12 : 16)
     }
 }

--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -298,6 +298,10 @@ struct HomeView: View {
             }
         }
         .buttonStyle(.plain)
+        // Prevent NavigationLink from stretching to the LazyHStack's full
+        // proposed row height (226 pt); let the card use its natural height
+        // so LazyHStack(alignment: .top) can pin all cards at the same top edge.
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private func albumCard(_ album: AlbumSummary) -> some View {
@@ -467,7 +471,7 @@ struct CoverCardBody: View {
                 .lineLimit(2)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(.primary)
-                .frame(maxWidth: flexibleWidth ? .infinity : size, alignment: .leading)
+                .frame(maxWidth: flexibleWidth ? .infinity : size, minHeight: 36, alignment: .topLeading)
             if let subtitle, !subtitle.isEmpty {
                 Text(subtitle)
                     .font(.system(size: 11))

--- a/Sources/Kumone/Features/IOSMainWindow.swift
+++ b/Sources/Kumone/Features/IOSMainWindow.swift
@@ -658,6 +658,11 @@ struct IOSLibraryView: View {
                     }
                 }
             }
+
+            Section {
+                PlayerClearanceSpacer()
+                    .listRowBackground(Color.clear)
+            }
         }
         .navigationTitle("我的")
         .toolbar {

--- a/Sources/Kumone/Features/Navigation.swift
+++ b/Sources/Kumone/Features/Navigation.swift
@@ -121,11 +121,27 @@ extension View {
 /// Trailing spacer for scrollable pages so the last row clears the
 /// floating player bar.
 struct PlayerClearanceSpacer: View {
+    @EnvironmentObject private var player: PlayerService
+
     var body: some View {
         #if os(iOS)
-        Color.clear.frame(height: 80) // mini player bar above the tab bar
+        if #available(iOS 26.0, *) {
+            // On iOS 26+, the native TabView bottom accessory automatically
+            // expands the content safe area insets; keep only the breathing margin.
+            Color.clear.frame(height: Theme.Layout.scrollBreathingMargin)
+        } else {
+            // On iOS < 26, customTabInterface floats above content and requires
+            // explicit bottom clearance.
+            Color.clear.frame(
+                height: player.hasCurrentTrack
+                    ? Theme.Layout.FloatingChrome.fullChromeClearance
+                    : Theme.Layout.FloatingChrome.tabBarClearance
+            )
+        }
         #else
-        Color.clear.frame(height: Theme.Layout.playerChromeClearance + 8)
+        Color.clear.frame(
+            height: Theme.Layout.playerChromeClearance + Theme.Layout.scrollBreathingMargin
+        )
         #endif
     }
 }

--- a/Sources/Kumone/Features/Pages/FMView.swift
+++ b/Sources/Kumone/Features/Pages/FMView.swift
@@ -7,6 +7,14 @@ struct FMView: View {
     @Environment(\.openLogin) private var openLogin
     @Environment(\.colorScheme) private var colorScheme
 
+    private var isPhone: Bool {
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        return false
+        #endif
+    }
+
     var body: some View {
         ZStack {
             backdrop
@@ -48,66 +56,83 @@ struct FMView: View {
     // MARK: - Content
 
     private var content: some View {
-        VStack(spacing: 28) {
-            Spacer()
+        GeometryReader { geo in
+            let maxDim: CGFloat = isPhone ? 240 : 300
+            let coverDimension = max(110, min(maxDim, min(geo.size.width - 48, geo.size.height * 0.38)))
+            let spacing: CGFloat = isPhone ? (geo.size.height < 520 ? 12 : 20) : 28
 
-            ZStack {
-                if let cover = track?.album.picUrl?.resizedImageURL(768) {
-                    CachedAsyncImage(url: cover)
-                        .frame(width: 300, height: 300)
-                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                        .shadow(color: .black.opacity(0.35), radius: 28, y: 14)
-                } else {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(.quaternary.opacity(0.4))
-                        .frame(width: 300, height: 300)
-                        .overlay(
-                            Image(systemName: "wave.3.right.circle")
-                                .font(.system(size: 56, weight: .light))
-                                .foregroundStyle(.tertiary)
-                        )
-                }
-            }
-            .scaleEffect(player.isPlaying && player.isFMMode ? 1 : 0.94)
-            .animation(AppAnimation.bouncy, value: player.isPlaying && player.isFMMode)
+            VStack(spacing: spacing) {
+                Spacer()
 
-            VStack(spacing: 6) {
-                HStack(spacing: 8) {
-                    Text(track?.name ?? String(localized: "私人漫游"))
-                        .font(.system(size: 22, weight: .bold))
-                        .lineLimit(1)
-                    if track?.fee == 1 {
-                        VIPBadge()
+                ZStack {
+                    if let cover = track?.album.picUrl?.resizedImageURL(768) {
+                        CachedAsyncImage(url: cover)
+                            .frame(width: coverDimension, height: coverDimension)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                            .shadow(color: .black.opacity(0.35), radius: 28, y: 14)
+                    } else {
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(.quaternary.opacity(0.4))
+                            .frame(width: coverDimension, height: coverDimension)
+                            .overlay(
+                                Image(systemName: "wave.3.right.circle")
+                                    .font(
+                                        .system(
+                                            size: max(32, coverDimension * 0.25),
+                                            weight: .light
+                                        )
+                                    )
+                                    .foregroundStyle(.tertiary)
+                            )
                     }
                 }
-                Text(track?.artistNames ?? String(localized: "根据你的口味漫游好音乐"))
-                    .font(.system(size: 14))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: 420)
+                .scaleEffect(player.isPlaying && player.isFMMode ? 1 : 0.94)
+                .animation(AppAnimation.bouncy, value: player.isPlaying && player.isFMMode)
 
-            if player.isFMMode {
-                controls
-            } else {
-                Button {
-                    player.startFM()
-                } label: {
-                    Label("开始漫游", systemImage: "wave.3.right")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 28)
-                        .padding(.vertical, 12)
-                        .background(Theme.accentGradient, in: Capsule())
-                        .shadow(color: Theme.accent.opacity(0.35), radius: 10, y: 3)
+                VStack(spacing: 6) {
+                    HStack(spacing: 8) {
+                        Text(track?.name ?? String(localized: "私人漫游"))
+                            .font(
+                                .system(
+                                    size: isPhone && geo.size.height < 520 ? 18 : 22,
+                                    weight: .bold
+                                )
+                            )
+                            .lineLimit(1)
+                        if track?.fee == 1 {
+                            VIPBadge()
+                        }
+                    }
+                    Text(track?.artistNames ?? String(localized: "根据你的口味漫游好音乐"))
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
-                .buttonStyle(.pressable)
-            }
+                .frame(maxWidth: 420)
 
-            Spacer()
-            Spacer()
+                if player.isFMMode {
+                    controls
+                } else {
+                    Button {
+                        player.startFM()
+                    } label: {
+                        Label("开始漫游", systemImage: "wave.3.right")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 28)
+                            .padding(.vertical, 12)
+                            .background(Theme.accentGradient, in: Capsule())
+                            .shadow(color: Theme.accent.opacity(0.35), radius: 10, y: 3)
+                    }
+                    .buttonStyle(.pressable)
+                }
+
+                Spacer()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 40)
         }
-        .padding(.horizontal, 40)
     }
 
     private var controls: some View {

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -963,12 +963,15 @@ private struct IOSImmersiveLyricsColumn: View {
                         LazyVStack(alignment: .leading, spacing: 22) {
                             Color.clear.frame(height: 72)
                             ForEach(lyrics.lines) { line in
-                                lyricLine(line, isActive: line.id == activeIndex)
-                                    .id(line.id)
+                                lyricLine(
+                                    line,
+                                    isActive: line.id == activeIndex
+                                )
+                                .id(line.id)
                             }
                             Color.clear.frame(height: 96)
                         }
-                        .padding(.horizontal, 2)
+                        .padding(.horizontal, 4)
                     }
                     .mask(edgeMask)
                     .accessibilityIdentifier("syncedLyricsScroll")
@@ -989,16 +992,17 @@ private struct IOSImmersiveLyricsColumn: View {
                     .simultaneousGesture(
                         DragGesture()
                             .onChanged { _ in
-                                guard !isUserScrolling else { return }
-                                resumeTask?.cancel()
                                 isUserScrolling = true
-                            }
-                            .onEnded { _ in
                                 resumeTask?.cancel()
-                                resumeTask = Task {
+                                resumeTask = Task { @MainActor in
                                     try? await Task.sleep(for: .seconds(3))
                                     guard !Task.isCancelled else { return }
                                     isUserScrolling = false
+                                    if let activeIndex {
+                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+                                            proxy.scrollTo(activeIndex, anchor: .center)
+                                        }
+                                    }
                                 }
                             }
                     )
@@ -1035,7 +1039,9 @@ private struct IOSImmersiveLyricsColumn: View {
         activeIndex = index
         guard let index else { return }
         DispatchQueue.main.async {
-            proxy.scrollTo(index, anchor: .center)
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
+                proxy.scrollTo(index, anchor: .center)
+            }
         }
     }
 
@@ -1060,28 +1066,31 @@ private struct IOSImmersiveLyricsColumn: View {
                 if settings.lyricsAnnotation == .romaji, let romaji = line.romaji {
                     Text(romaji)
                         .font(.system(size: isActive ? 15 : 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                        .foregroundStyle(.white.opacity(isActive ? 0.75 : 0.4))
                 }
 
                 LyricMainText(
-                    line: line, isActive: isActive,
-                    size: 27, weight: isActive ? .bold : .semibold,
+                    line: line,
+                    isActive: isActive,
+                    size: isActive ? 26 : 21,
+                    weight: isActive ? .bold : .semibold,
                     verbatim: settings.verbatimLyrics
                 )
 
                 if settings.showLyricsTranslation, let translation = line.translation {
                     Text(translation)
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundStyle(.white.opacity(isActive ? 0.7 : 0.35))
+                        .font(.system(size: isActive ? 16 : 14, weight: .medium))
+                        .foregroundStyle(.white.opacity(isActive ? 0.75 : 0.4))
                 }
             }
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
-            .scaleEffect(isActive ? 1.07 : 0.82, anchor: .leading)
+            .blur(radius: isActive ? 0 : 0.4)
+            .scaleEffect(isActive ? 1.02 : 1.0, anchor: .leading)
         }
         .buttonStyle(.plain)
-        .animation(.spring(response: 0.28, dampingFraction: 0.9), value: isActive)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: isActive)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses several UI alignment, layout overflow, and playback interaction issues on iOS:

1. **Playlist Card & Shelf Alignment**:
   - Fixed vertical grid staggering and shelf item dropping caused by mixed 1-line and 2-line title lengths.
   - Unified card title `minHeight` to 36pt with top-leading alignment.
   - Added `.fixedSize(horizontal: false, vertical: true)` to `NavigationLink` in shelf rows to prevent unintended vertical stretching and centering inside the proposed row height.

2. **Detail Skeleton Headers Standardization**:
   - Unified skeleton header placeholder bars to a consistent 14pt height across `PlaylistDetailView`, `AlbumDetailView`, and `ArtistDetailView` with aligned margins.

3. **FM Page Dynamic Responsiveness**:
   - Replaced fixed artwork sizing with `GeometryReader`-based dynamic scaling on compact/landscape heights to prevent controls and metadata from being pushed off-screen.

4. **Immersive Lyrics Interaction & Transitions**:
   - Improved drag gesture debounce and auto-scroll recovery (auto-scroll smoothly resumes to active line 3s after user finishes dragging).
   - Tuned text scale effect and transition animations to prevent layout jitter during active lyric line changes.

5. **Floating Bottom Chrome Clearance**:
   - Refined `PlayerClearanceSpacer` and `Theme.Layout.FloatingChrome` to accurately calculate bottom safe area clearance on iOS < 26 (custom floating bar) vs iOS 26+ (native TabView bottom accessory).

## Verification
- Built and verified on iOS Simulator (iPhone 11 Pro / iOS 16.6 and iPhone 17 Pro).
- Tested 1-line vs 2-line playlist card alignments in both Grid and horizontal Shelf.
- Verified FM view layout across portrait and compact heights.
- Tested lyrics manual scroll vs auto-follow playback transitions.