### PR TITLE
fix(ui): align playlist card artwork

### DIFF
--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -444,23 +444,24 @@ struct CoverCardBody: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ZStack(alignment: .bottomLeading) {
-                artwork
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.standard, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Theme.Radius.standard, style: .continuous)
-                            .strokeBorder(.primary.opacity(0.08), lineWidth: 0.5)
-                    )
-                if playCount > 0 {
-                    PlayCountBadge(count: playCount)
-                        .padding(6)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            artwork
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.standard, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.standard, style: .continuous)
+                        .strokeBorder(.primary.opacity(0.08), lineWidth: 0.5)
+                )
+                .overlay(alignment: .topTrailing) {
+                    if playCount > 0 {
+                        PlayCountBadge(count: playCount)
+                            .padding(6)
+                    }
                 }
-                if let onPlay {
-                    PlayOverlayButton(visible: isHovering, action: onPlay)
-                        .padding(8)
+                .overlay(alignment: .bottomLeading) {
+                    if let onPlay {
+                        PlayOverlayButton(visible: isHovering, action: onPlay)
+                            .padding(8)
+                    }
                 }
-            }
 
             Text(title)
                 .font(.system(size: 13, weight: .medium))


### PR DESCRIPTION

## 问题

推荐页和精选页的歌单卡片存在封面上下排列不齐的问题。

当歌单标题行数或副标题内容不同时，部分封面会向下偏移，播放量徽标也可能与封面分离。相邻卡片因此无法保持统一的顶部对齐，在推荐页的横向歌单和精选页的歌单网格中都会出现。

## 原因

两个页面共用的 `CoverCardBody` 使用 `ZStack` 放置封面、播放量徽标和悬浮播放按钮。

播放量徽标通过无限高度的 `frame` 定位到右上角，因此参与了父容器的尺寸计算。卡片标题和副标题占用的高度不同时，封面区域获得的剩余高度也不同；由于封面按底部对齐，最终产生了不同程度的纵向偏移。

## 修复方案

- 让封面本身作为卡片布局的尺寸基准。
- 将播放量徽标改为封面右上角的 `overlay`。
- 将悬浮播放按钮改为封面左下角的 `overlay`。
- 避免徽标和按钮参与封面容器的尺寸计算。
- 保留紧凑宽度下歌单卡片的自适应布局，不影响 iPhone 双列展示。

## 修复结果

- 推荐页的歌单封面恢复统一顶部对齐。
- 精选页的歌单网格同步恢复整齐排列。
- 播放量徽标固定在封面右上角，不再与封面分离。
- macOS 悬浮播放按钮仍保持在封面左下角。
- 不同长度的标题和有无副标题不再影响封面位置。

## 验证

- 使用 Xcode 26.2、Swift 6.2.3 完成 Debug 应用构建。
- `.app` 打包及签名校验通过。
- Swift 测试全部通过：2 tests，0 failures。
