### PR TITLE
feat(ios): CarPlay 支持（opt-in，默认关闭）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 section the English bullets come first, followed by their Simplified Chinese
 counterparts. 段落格式：`## <版本号> - <日期>`，条目必须写成单行。
 
+## 0.3.15 - 2026-08-31
+
+### Added / 新增
+
+- **iOS**: CarPlay support — strict 4-tab mirror of the App's main UI (推荐 / 精选 / 漫游 / 我的): 推荐 tab exposes 每日推荐 / 推荐歌单 / 雷达歌单 / 排行榜 / 新碟上架 / 推荐歌手; 精选 tab exposes 精品 / 热门 / 排行榜 / 官方 / 华语; 漫游 tab is a single start/skip row; 我的 tab exposes 我的音乐 (with 每日推荐 / 最近播放 / 音乐云盘 / 我喜欢的音乐) + 创建的歌单 + 收藏的歌单. Now Playing gains a 喜欢 button (always on) and a 不喜欢 / trash button (FM mode only, matching the App's FMView); ±15s skip, shuffle, and repeat commands also route through CarPlay's Now Playing buttons.
+- **iOS**：新增 CarPlay 支持——严格对齐 App 主界面的 4 个 Tab（推荐 / 精选 / 漫游 / 我的）：推荐 tab 含 每日推荐 / 推荐歌单 / 雷达歌单 / 排行榜 / 新碟上架 / 推荐歌手；精选 tab 含 精品 / 热门 / 排行榜 / 官方 / 华语；漫游 tab 单按钮开始/换一首；我的 tab 含 我的音乐（含每日推荐 / 最近播放 / 音乐云盘 / 我喜欢的音乐）+ 创建的歌单 + 收藏的歌单。Now Playing 新增 喜欢按钮（始终可用）和 trash / 不喜欢按钮（仅在 FM 模式显示，对齐 App FMView）；±15秒快进快退、随机、循环按钮均已接通。
+
+### Fixed / 修复
+
+- **iOS**: CarPlay 漫游 tab now reflects the live playback state — a "正在漫游" row surfaces the currently playing track while FM is on, the action button toggles 换一首 / 继续漫游 with the actual isPlaying value, and the tab no longer restarts FM when paused. The CarPlay connector now subscribes to both `$isFMMode` and `$isPlaying` so the FM template refreshes whenever playback state changes.
+- **iOS**：CarPlay 漫游 tab 现在会同步播放状态：FM 模式下显示"正在漫游"行（当前曲目），操作按钮随 `isPlaying` 在"换一首 / 继续漫游"之间切换，FM 暂停时点击按钮是继续而不是重启 FM。CarPlay 连接器同时订阅 `$isFMMode` 和 `$isPlaying`，播放状态变化时刷新 FM 模板。
+- **iOS**: the `com.apple.developer.carplay-audio` entitlement is now left commented in `ios/Config/KumoneIOS.entitlements` by default, and a ready-to-copy template is added at `ios/Config/KumoneIOS.entitlements.example`. CarPlay activation requires the [Apple CarPlay audio capability](https://developer.apple.com/contact/carplay/) which most developer accounts are not granted; leaving the entitlement on without approval breaks real-device builds with `Entitlement ... not found and could not be included in profile`. CarPlay code and Info.plist scene configuration remain in place — once Apple approval lands, just uncomment and re-sign. README updated with the enable steps.
+- **iOS**：`com.apple.developer.carplay-audio` 在 `ios/Config/KumoneIOS.entitlements` 中默认改为注释状态，并新增模板文件 `ios/Config/KumoneIOS.entitlements.example`。CarPlay 激活需要 [Apple CarPlay 音频能力](https://developer.apple.com/contact/carplay/)，多数开发者账号不会被授予；未授权时打开会导致真机签名失败（`Entitlement ... not found and could not be included in profile`）。CarPlay 实现代码与 Info.plist scene 配置保持不变——拿到 Apple 授权后取消注释重新签名即可。README 同步更新启用步骤。
+
 ## 0.3.14 - 2026-08-29
 
 ### Added / 新增

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Built with SwiftUI · Talks directly to NetEase's real API · Sparkle auto-updat
 - 🏠 **Home** — daily recommendations, Personal FM, Heartbeat Mode, recommended playlists, radar playlists (Personal Radar family, personalized per account), charts, new albums, recommended artists
 - 🧭 **Explore** — category playlists (curated / official / charts / mood) with infinite scrolling
 - 🎵 **Playback** — AVPlayer engine, Standard to Hi-Res quality (lossless with 黑胶 VIP, automatic fallback), shuffle / repeat one / repeat all, play-next queue, gray track detection
+- 🚗 **CarPlay (iOS, opt-in)** — Now Playing, tabbed library, queue, and search templates ship in the binary; activation requires an [Apple CarPlay audio entitlement](https://developer.apple.com/contact/carplay/), which is not granted to most accounts. Build defaults to disabled so the source tree stays open-source-friendly; see [Enabling CarPlay](#enabling-carplay-ios) below
 - 🔓 **Gray track unblocking** — native implementation of UnblockNeteaseMusic's core sources (pyncmd / Kuwo / Kugou); unavailable or trial-only tracks automatically resolve from third-party sources
 - 🖼 **Immersive now-playing page** — artwork-tinted gradient backdrop, large artwork, big synced lyrics (click the player-bar artwork to open, Esc to close)
 - 📻 **Personal FM** — immersive roaming page with trash / skip
@@ -94,6 +95,35 @@ the same mechanism Dopamine uses. This works **only under TrollStore**: a plain
 AltStore/SideStore sideload is signed with a personal certificate and has no way
 to install an IPA on-device, so there it degrades to opening the release page
 for a manual re-sideload.
+
+### Enabling CarPlay (iOS)
+
+CarPlay support is fully implemented in `Sources/Kumone/Core/CarPlay/` and the
+Info.plist already declares `UISupportsCarPlay` plus the CarPlay scene
+configuration. However the `com.apple.developer.carplay-audio` entitlement is
+**opt-in**: Apple only grants it after you submit a CarPlay audio app
+[application](https://developer.apple.com/contact/carplay/), so it is left
+commented in `ios/Config/KumoneIOS.entitlements` by default — leaving it on
+without approval makes real-device builds fail with:
+
+> Entitlement com.apple.developer.carplay-audio not found and could not be
+> included in profile.
+
+To enable CarPlay once your developer account has the entitlement approved:
+
+1. Apply for and obtain the **CarPlay (Audio)** capability for your App ID in
+   [Apple Developer → Identifiers](https://developer.apple.com/account/resources/certificates/list).
+2. Regenerate the provisioning profile so it carries the new capability.
+3. Open `ios/Config/KumoneIOS.entitlements`, uncomment the
+   `com.apple.developer.carplay-audio` block (a ready-to-copy template lives in
+   [`ios/Config/KumoneIOS.entitlements.example`](ios/Config/KumoneIOS.entitlements.example)).
+4. In Xcode → **Signing & Capabilities**, add the **CarPlay** capability and
+   tick **Audio**.
+5. `Cmd + Shift + K` and rebuild.
+
+A reference template of the entitlement value is provided at
+`ios/Config/KumoneIOS.entitlements.example` — copy it into
+`KumoneIOS.entitlements` once you have Apple approval.
 
 ## Building
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,6 +41,7 @@ SwiftUI 编写 · 直连网易云真实 API · Sparkle 自动更新
 - 🏠 **推荐** — 每日推荐、私人漫游、心动模式、推荐歌单、雷达歌单（私人雷达系列，按账号个性化）、排行榜、新碟上架、推荐歌手
 - 🧭 **精选** — 分类歌单（精品 / 官方 / 排行榜 / 场景分类）无限滚动
 - 🎵 **播放** — AVPlayer 引擎，标准 ~ Hi-Res 音质可选（黑胶 VIP 可播无损，自动回落），随机 / 单曲循环 / 列表循环，下一首播放队列，灰色歌曲识别
+- 🚗 **CarPlay（iOS，按需开启）** — Now Playing、分类音乐库、播放队列与搜索模板已写入二进制；激活需 [Apple 授权的 CarPlay 音频能力](https://developer.apple.com/contact/carplay/)，大多数账号不会被授予。默认关闭以保证开源源码树可直接编译，详见下方[启用 CarPlay](#启用-carplayios)
 - 🔓 **灰色歌曲解锁** — 原生实现 UnblockNeteaseMusic 核心音源（pyncmd / 酷我 / 酷狗），无版权或试听歌曲自动匹配第三方音源
 - 🖼 **沉浸播放页** — 封面取色渐变背景 + 大封面 + 大字同步歌词（点击播放条封面进入，Esc 退出）
 - 📻 **私人漫游** — 沉浸式 FM 页面，不喜欢 / 切歌
@@ -79,6 +80,23 @@ brew install owo-network/brew/kumone --cask
 #### 应用内自动更新（仅限 TrollStore / 巨魔）
 
 在装有 **[TrollStore](https://github.com/opa334/TrollStore)（巨魔）** 的设备上，Kumone 可自我更新：设置 → 关于 → **检查更新**（启动时也会检查）会带进度圆环下载新 IPA，并通过 `apple-magnifier://install?url=…` 移交给 TrollStore 一键自动安装 —— 与 Dopamine 的机制相同。此功能**仅在 TrollStore 下可用**：普通 AltStore/SideStore 侧载版以个人证书签名，没有在设备上安装 IPA 的权限，因此会降级为打开发布页手动重新侧载。
+
+### 启用 CarPlay（iOS）
+
+CarPlay 的实现代码已完整存在于 `Sources/Kumone/Core/CarPlay/`，`Info.plist` 也已声明 `UISupportsCarPlay` 与 CarPlay scene 配置。但 `com.apple.developer.carplay-audio` 这一 entitlement **默认注释掉**，因为它需要先向 Apple 提交 CarPlay 音频应用[申请](https://developer.apple.com/contact/carplay/)并获批；多数账号不会被授予该能力。直接打开该 entitlement 会让真机编译失败：
+
+> Entitlement com.apple.developer.carplay-audio not found and could not be
+> included in profile.
+
+待 Apple 授权后，按下列步骤启用：
+
+1. 在 [Apple Developer → Identifiers](https://developer.apple.com/account/resources/certificates/list) 为你的 App ID 勾选 **CarPlay (Audio)** 能力。
+2. 重新生成 provisioning profile 以携带新能力。
+3. 打开 `ios/Config/KumoneIOS.entitlements`，取消 `com.apple.developer.carplay-audio` 那一段的注释（参考模板见 [`ios/Config/KumoneIOS.entitlements.example`](ios/Config/KumoneIOS.entitlements.example)）。
+4. 在 Xcode → **Signing & Capabilities** 添加 **CarPlay** 能力并勾选 **Audio**。
+5. `Cmd + Shift + K` 清理后重新构建。
+
+模板文件 `ios/Config/KumoneIOS.entitlements.example` 已就绪——拿到 Apple 授权后，将其内容复制/合并进 `KumoneIOS.entitlements` 即可。
 
 ## 构建
 

--- a/Sources/Kumone/Core/CarPlay/CarPlayConnector.swift
+++ b/Sources/Kumone/Core/CarPlay/CarPlayConnector.swift
@@ -1,0 +1,760 @@
+// CarPlayConnector.swift — CarPlay lifecycle + template assembly + tap bridging.
+// The single public type in KumoneCore, forwarded to by the app target's CarPlaySceneDelegate.
+
+#if os(iOS)
+import CarPlay
+import Combine
+import UIKit
+
+/// Owns the CarPlay connection lifecycle, the template hierarchy, and data loading.
+/// It's a singleton — activated when a CarPlay scene connects, cleaned up when it disconnects.
+@MainActor
+public final class CarPlayConnector: NSObject {
+
+    public static let shared = CarPlayConnector()
+
+    // MARK: - State
+
+    private weak var interfaceController: CPInterfaceController?
+    private var tabBar: CPTabBarTemplate?
+    private var recommendTab: CPListTemplate?
+    private var curatedTab: CPListTemplate?
+    private var fmTab: CPListTemplate?
+    private var libraryTab: CPListTemplate?
+
+    private var content = CarPlayContentStore()
+    private var cancellables: Set<AnyCancellable> = []
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
+
+    // MARK: - Now Playing buttons (like / dislike are created in didConnect and cached)
+    private var likeButton: CPNowPlayingAddToLibraryButton?
+    private var dislikeButton: CPNowPlayingImageButton?
+
+    override init() {
+        super.init()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Called when the CarPlay scene connects. Builds the root template and kicks off data loading.
+    public func didConnect(interfaceController: CPInterfaceController, window: CPWindow) {
+        self.interfaceController = interfaceController
+        cancellables.removeAll()
+
+        // Force PlayerService to initialize (sets up the audio session and remote commands).
+        _ = PlayerService.shared
+
+        // Login / logout → rebuild every tab from scratch.
+        AccountStore.shared.$profile
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.rebuildAllTabs()
+            }
+            .store(in: &cancellables)
+
+        // userPlaylists changes → only refresh the Library tab. (Also fires on logout when the list gets emptied.)
+        AccountStore.shared.$userPlaylists
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.refreshLibraryTab()
+            }
+            .store(in: &cancellables)
+
+        // FM mode toggle → flips the FM tab action button between "Start Roaming" and "Next", and shows/hides the dislike button on Now Playing.
+        PlayerService.shared.$isFMMode
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] isFM in
+                self?.updateNowPlayingButtons(isFMMode: isFM)
+                self?.updateFMTab()
+            }
+            .store(in: &cancellables)
+
+        // Subscribe to isPlaying in addition to isFMMode: the action button label
+        // ("Next" vs "Resume Roaming") and the "Now Roaming" row both need to react
+        // when playback starts or stops. Watching only isFMMode is what caused the
+        // original sync bug — the button would stay stuck on "Start Roaming" forever
+        // even after FM was actually playing, because isFMMode flips to true
+        // synchronously inside startFM(), well before fmAdvance() has finished
+        // fetching tracks and startPlaying() has flipped isPlaying to true.
+        // Without this observer there's no later trigger to refresh the tab.
+        PlayerService.shared.$isPlaying
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.updateFMTab()
+            }
+            .store(in: &cancellables)
+
+        // Current track changes → sync the Now Playing "like" button's selected state.
+        PlayerService.shared.$currentTrack
+            .removeDuplicates(by: { $0?.id == $1?.id })
+            .sink { [weak self] track in
+                guard let self else { return }
+                let liked = track.map { AccountStore.shared.isLiked($0.id) } ?? false
+                self.likeButton?.isSelected = liked
+            }
+            .store(in: &cancellables)
+
+        // Liked-IDs changes (user toggled like somewhere else in the UI) → keep the Now Playing "like" button in sync.
+        AccountStore.shared.$likedTrackIDs
+            .sink { [weak self] _ in
+                guard let self,
+                      let track = PlayerService.shared.currentTrack else { return }
+                self.likeButton?.isSelected = AccountStore.shared.isLiked(track.id)
+            }
+            .store(in: &cancellables)
+
+        // Configure the Now Playing buttons (persistent — live for the singleton's lifetime).
+        configureNowPlayingButtons()
+
+        // Build and install the root template.
+        let root = makeRootTemplate()
+        tabBar = root
+        interfaceController.setRootTemplate(root, animated: true, completion: nil)
+
+        // On cold start, finish account bootstrap first, then load all four tabs in their final logged-in/out state.
+        scheduleFullReload(bootstrapIfNeeded: true)
+    }
+
+    /// Called when the CarPlay scene disconnects. Clears template references but doesn't stop playback.
+    public func didDisconnect() {
+        cancellables.removeAll()
+        loadGeneration += 1
+        loadTask?.cancel()
+        loadTask = nil
+        interfaceController = nil
+        tabBar = nil
+        recommendTab = nil
+        curatedTab = nil
+        fmTab = nil
+        libraryTab = nil
+    }
+
+    // MARK: - Root template
+
+    /// Builds the CPTabBarTemplate (Recommend / Curated / Roaming / Library) — mirrors the App's IOSTab layout 1:1.
+    private func makeRootTemplate() -> CPTabBarTemplate {
+        let recommend = CPListTemplate(title: "推荐", sections: [])
+        recommend.tabImage = UIImage(systemName: "house")
+        recommend.emptyViewTitleVariants = ["正在加载推荐…"]
+
+        let curated = CPListTemplate(title: "精选", sections: [])
+        curated.tabImage = UIImage(systemName: "square.grid.2x2")
+        curated.emptyViewTitleVariants = ["正在加载精选…"]
+
+        let fm = CPListTemplate(title: "漫游", sections: [])
+        fm.tabImage = UIImage(systemName: "dot.radiowaves.left.and.right")
+        fm.emptyViewTitleVariants = [String(localized: "请先登录网易云音乐")]
+
+        let library = CPListTemplate(title: "我的", sections: [])
+        library.tabImage = UIImage(systemName: "person.crop.circle")
+        library.emptyViewTitleVariants = [String(localized: "请先登录网易云音乐")]
+
+        let nowPlaying = CPNowPlayingTemplate.shared
+        // 3rd-party audio apps don't have a queue API, so disable the Up Next button to avoid a dead control.
+        nowPlaying.isUpNextButtonEnabled = false
+
+        self.recommendTab = recommend
+        self.curatedTab = curated
+        self.fmTab = fm
+        self.libraryTab = library
+
+        // CPNowPlayingTemplate is auto-presented by CarPlay whenever audio plays; it can't be added as a CPTabBarTemplate tab.
+        return CPTabBarTemplate(templates: [recommend, curated, fm, library])
+    }
+
+    // MARK: - Now Playing button configuration
+
+    /// Creates and caches the like / dislike buttons in didConnect, then installs them on CPNowPlayingTemplate.
+    /// - like (CPNowPlayingAddToLibraryButton): always shown, mirrors the App's global LikeButton.
+    /// - dislike (CPNowPlayingImageButton): only shown and enabled while in FM mode, mirroring the trash button in the App's FMView.
+    private func configureNowPlayingButtons() {
+        let nowPlaying = CPNowPlayingTemplate.shared
+        nowPlaying.isUpNextButtonEnabled = false   // 3rd-party audio apps don't expose a queue API.
+
+        // "Like" button — uses the system's "add to library" styled button.
+        let like = CPNowPlayingAddToLibraryButton(handler: { [weak self] _ in
+            guard let trackID = PlayerService.shared.currentTrack?.id else { return }
+            Task { await AccountStore.shared.toggleLike(trackID: trackID) }
+        })
+        like.isEnabled = true
+        like.isSelected = PlayerService.shared.currentTrack
+            .map { AccountStore.shared.isLiked($0.id) } ?? false
+        self.likeButton = like
+
+        // "Dislike" button — custom SF Symbol icon, only shown and enabled while FM mode is on.
+        let dislike = CPNowPlayingImageButton(
+            image: UIImage(systemName: "hand.thumbsdown.fill")!,
+            handler: { _ in PlayerService.shared.fmTrash() }
+        )
+        dislike.isEnabled = PlayerService.shared.isFMMode
+        self.dislikeButton = dislike
+
+        updateNowPlayingButtons(isFMMode: PlayerService.shared.isFMMode)
+    }
+
+    private func updateNowPlayingButtons(isFMMode: Bool) {
+        guard let likeButton, let dislikeButton else { return }
+        dislikeButton.isEnabled = isFMMode
+        CPNowPlayingTemplate.shared.updateNowPlayingButtons(
+            isFMMode ? [likeButton, dislikeButton] : [likeButton]
+        )
+    }
+
+    // MARK: - Data loading
+
+    /// The Recommend tab's section order matches `HomeView.loadedBody` 1:1.
+    private static let homeToplistWhitelist: Set<Int> = [
+        19_723_756, 3_779_629, 2_884_035, 3_778_678, 60_198
+    ]
+
+    /// Loads all four tabs' data into an independent snapshot in parallel.
+    /// The last three fetchers are guarded by `loggedIn` so logged-out callers don't hit a guaranteed 401.
+    private func loadAllTabs(into content: CarPlayContentStore, loggedIn: Bool) async {
+        async let r: Void = content.fetchRecommendPlaylists(loggedIn: loggedIn)
+        async let c: Void = content.fetchCuratedPlaylists()
+        async let o: Void = content.fetchOfficialPlaylists()
+        async let ch: Void = content.fetchChinesePlaylists()
+        async let t: Void = content.fetchToplists()
+        async let d: Void = content.fetchDailyTracks(loggedIn: loggedIn)
+        async let e: Void = content.fetchRecentsTracks(loggedIn: loggedIn)
+        async let l: Void = content.fetchCloudTracks(loggedIn: loggedIn)
+        async let rd: Void = content.fetchRadarPlaylists(loggedIn: loggedIn)
+        async let al: Void = content.fetchNewAlbums()
+        async let ar: Void = content.fetchTopArtists()
+
+        _ = await (r, c, o, ch, t, d, e, l, rd, al, ar)
+    }
+
+    /// Only the latest batch of requests is allowed to commit, so cold-start or account-switch races can't let an older account's data clobber a newer one.
+    private func scheduleFullReload(bootstrapIfNeeded: Bool) {
+        loadGeneration += 1
+        let generation = loadGeneration
+        loadTask?.cancel()
+        loadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            if bootstrapIfNeeded, !AccountStore.shared.isBootstrapped {
+                await AccountStore.shared.bootstrap()
+            }
+            guard !Task.isCancelled,
+                  generation == loadGeneration,
+                  interfaceController != nil else { return }
+
+            let nextContent = CarPlayContentStore()
+            let loggedIn = AccountStore.shared.isLoggedIn
+            await loadAllTabs(into: nextContent, loggedIn: loggedIn)
+            guard !Task.isCancelled,
+                  generation == loadGeneration,
+                  interfaceController != nil else { return }
+
+            content = nextContent
+            updateRecommendTab()
+            updateCuratedTab()
+            updateFMTab()
+            updateLibraryTab()
+        }
+    }
+
+    /// Refreshes the Recommend tab's sections, matching `App HomeView.loadedBody` exactly:
+    /// 1. Today's picks (feature cards: Daily / Personal FM / Heartbeat) — login-only
+    /// 2. Recommended playlists
+    /// 3. Radar playlists — login-only
+    /// 4. Toplists (5 fixed IDs, same as the App)
+    /// 5. New albums
+    /// 6. Recommended artists
+    private func updateRecommendTab() {
+        guard let recommendTab else { return }
+        var sections: [CPListSection] = []
+        let loggedIn = AccountStore.shared.isLoggedIn
+
+        // 1. Today's picks — feature cards
+        if loggedIn {
+            sections.append(contentsOf: CarPlayTemplateFactory.recommendFeatureSections(
+                onTap: { [weak self] feature in self?.handleRecommendFeatureTap(feature) }
+            ))
+        }
+
+        // 2. Recommended playlists
+        sections.append(contentsOf: CarPlayTemplateFactory.playlistSections(
+            content.recommendPlaylists,
+            onPlaylistTap: { [weak self] playlist in
+                self?.pushPlaylistDetail(playlist)
+            }
+        ))
+
+        // 3. Radar playlists — login-only
+        if loggedIn, !content.radarPlaylists.isEmpty {
+            sections.append(contentsOf: CarPlayTemplateFactory.radarPlaylistSections(
+                content.radarPlaylists,
+                onTap: { [weak self] radar in self?.pushRadarPlaylist(radar) }
+            ))
+        }
+
+        // 4. Toplists (5 entries, filtered with the same whitelist App HomeView uses).
+        let homeToplists = content.toplists.filter {
+            Self.homeToplistWhitelist.contains($0.id)
+        }
+        if !homeToplists.isEmpty {
+            let toplistItems = homeToplists.map { toplist -> CPListItem in
+                let item = CPListItem(text: toplist.name, detailText: toplist.updateFrequency)
+                item.accessoryType = .none
+                item.handler = { [weak self] _, completion in
+                    self?.pushToplistDetail(toplist)
+                    completion()
+                }
+                CarPlayTemplateFactory.fillArtwork(item, from: toplist.coverImgUrl)
+                return item
+            }
+            sections.append(CPListSection(items: toplistItems, header: "排行榜", sectionIndexTitle: nil))
+        }
+
+        // 5. New albums
+        if !content.newAlbums.isEmpty {
+            sections.append(contentsOf: CarPlayTemplateFactory.newAlbumSections(
+                content.newAlbums,
+                onTap: { [weak self] album in self?.pushAlbum(album) }
+            ))
+        }
+
+        // 6. Recommended artists
+        if !content.topArtists.isEmpty {
+            sections.append(contentsOf: CarPlayTemplateFactory.topArtistSections(
+                content.topArtists,
+                onTap: { [weak self] artist in self?.pushArtist(artist) }
+            ))
+        }
+
+        recommendTab.updateSections(sections)
+        if sections.isEmpty {
+            recommendTab.emptyViewTitleVariants = ["暂无推荐歌单"]
+        }
+    }
+
+    /// Tap handler for the Recommend tab's top feature rows:
+    /// - Daily → push the tracks list (reuses the Library tab's .daily entry)
+    /// - Personal FM → start FM
+    /// - Heartbeat → use `likedSongsPlaylist` + `likedTrackIDs` to drive `intelligenceList` (same as HomeView)
+    private func handleRecommendFeatureTap(_ feature: CarPlayRecommendFeature) {
+        switch feature {
+        case .daily:
+            pushLibraryEntry(.daily, liked: nil)
+        case .fm:
+            PlayerService.shared.startFM()
+        case .heartbeat:
+            startHeartbeatMode()
+        }
+    }
+
+    /// Heartbeat mode: pick one random liked track as a seed, then ask
+    /// `intelligenceList` for a similar queue. Copied from `HomeView.startHeartbeatMode`
+    /// so we don't have to expose HomeView to CarPlay.
+    private func startHeartbeatMode() {
+        let account = AccountStore.shared
+        guard let likedList = account.likedSongsPlaylist else {
+            ToastCenter.shared.show(String(localized: "未找到我喜欢的音乐"))
+            return
+        }
+        Task {
+            guard let seed = account.likedTrackIDs.randomElement() else {
+                ToastCenter.shared.show(String(localized: "先收藏一些喜欢的歌曲吧"))
+                return
+            }
+            do {
+                let tracks = try await NeteaseAPI.intelligenceList(songID: seed, playlistID: likedList.id)
+                guard !tracks.isEmpty else {
+                    ToastCenter.shared.show(String(localized: "心动模式暂时不可用"))
+                    return
+                }
+                PlayerService.shared.play(
+                    tracks: tracks,
+                    source: .playlist(likedList.id),
+                    context: .heartbeat
+                )
+                ToastCenter.shared.show(String(localized: "已开启心动模式"))
+            } catch {
+                ToastCenter.shared.show(error.localizedDescription)
+            }
+        }
+    }
+
+    /// Refreshes the Curated tab's sections: high-quality + hot + toplists + official + Chinese playlists.
+    /// Mirrors the category chips in App ExploreView (All / Featured / Toplists / Official / Chinese).
+    private func updateCuratedTab() {
+        guard let curatedTab else { return }
+        var sections = CarPlayTemplateFactory.playlistSections(
+            content.highQualityPlaylists,
+            onPlaylistTap: { [weak self] playlist in
+                self?.pushPlaylistDetail(playlist)
+            }
+        )
+        if !content.hotPlaylists.isEmpty {
+            let hotItems = content.hotPlaylists.map { playlist -> CPListItem in
+                let item = CPListItem(text: playlist.name, detailText: nil)
+                item.accessoryType = .none
+                item.handler = { [weak self] _, completion in
+                    self?.pushPlaylistDetail(playlist)
+                    completion()
+                }
+                CarPlayTemplateFactory.fillArtwork(item, from: playlist.coverURL)
+                return item
+            }
+            sections.append(CPListSection(items: hotItems, header: "热门歌单", sectionIndexTitle: nil))
+        }
+        // Toplists get their own section below.
+        if !content.toplists.isEmpty {
+            let toplistItems = content.toplists.map { toplist -> CPListItem in
+                let item = CPListItem(text: toplist.name, detailText: toplist.updateFrequency)
+                item.accessoryType = .none
+                item.handler = { [weak self] _, completion in
+                    self?.pushToplistDetail(toplist)
+                    completion()
+                }
+                CarPlayTemplateFactory.fillArtwork(item, from: toplist.coverImgUrl)
+                return item
+            }
+            sections.append(CPListSection(items: toplistItems, header: "排行榜", sectionIndexTitle: nil))
+        }
+        // Official playlists — backs the "Official" chip in App ExploreView.
+        if !content.officialPlaylists.isEmpty {
+            sections.append(contentsOf: CarPlayTemplateFactory.playlistSections(
+                content.officialPlaylists,
+                onPlaylistTap: { [weak self] playlist in self?.pushPlaylistDetail(playlist) },
+                header: "官方歌单"
+            ))
+        }
+        // Chinese playlists — backs the "Chinese" chip in App ExploreView.
+        if !content.chinesePlaylists.isEmpty {
+            sections.append(contentsOf: CarPlayTemplateFactory.playlistSections(
+                content.chinesePlaylists,
+                onPlaylistTap: { [weak self] playlist in self?.pushPlaylistDetail(playlist) },
+                header: "华语歌单"
+            ))
+        }
+        curatedTab.updateSections(sections)
+        if content.highQualityPlaylists.isEmpty, content.hotPlaylists.isEmpty, content.toplists.isEmpty,
+           content.officialPlaylists.isEmpty, content.chinesePlaylists.isEmpty {
+            curatedTab.emptyViewTitleVariants = ["暂无精选歌单"]
+        }
+    }
+
+    /// Refreshes the Roaming tab on CarPlay. Logged-in users get the FM template
+    /// with the currently playing track row plus the action button (Start Roaming /
+    /// Next / Resume Roaming). Logged-out users see an empty view prompting them
+    /// to sign in to NetEase Music first.
+    private func updateFMTab() {
+        guard let fmTab else { return }
+        let loggedIn = AccountStore.shared.isLoggedIn
+        if !loggedIn {
+            fmTab.updateSections([])
+            fmTab.emptyViewTitleVariants = [String(localized: "请先登录网易云音乐")]
+            return
+        }
+        let player = PlayerService.shared
+        let sections = CarPlayTemplateFactory.fmSection(
+            isFMMode: player.isFMMode,
+            isPlaying: player.isPlaying,
+            currentTrack: player.currentTrack,
+            onActionTap: { [weak self] in self?.handleFMTap() }
+        )
+        fmTab.updateSections(sections)
+        fmTab.emptyViewTitleVariants = ["正在加载…"]
+    }
+
+    /// What happens when the driver taps the FM tab's action button, depending
+    /// on what the player is doing right now:
+    /// - FM mode is off entirely → fire `startFM()` to begin a fresh roaming
+    ///   session (fetches recommendations from NetEase and starts playing).
+    /// - FM mode is on and we're playing → skip ahead via `fmNext()`. We
+    ///   intentionally don't reuse `next()` here because FM doesn't use the
+    ///   normal queue — its tracks are pulled one batch at a time from
+    ///   NetEase's recommendation API, and CPNowPlayingTemplate's built-in
+    ///   "next" button doesn't know about that semantics. Putting the skip
+    ///   right on the FM tab keeps the driver's intent obvious.
+    /// - FM mode is on but we're paused → just resume with `togglePlayPause()`.
+    ///   Using `startFM()` here would wipe the FM queue and start a brand-new
+    ///   session, which is definitely not what the driver wants when they
+    ///   just hit pause and are tapping to come back.
+    private func handleFMTap() {
+        let player = PlayerService.shared
+        if !player.isFMMode {
+            player.startFM()
+        } else if player.isPlaying {
+            player.fmNext()
+        } else {
+            player.togglePlayPause()
+        }
+    }
+
+    /// Refreshes the Library tab: pulls `userPlaylists` from `AccountStore` and renders 3 sections.
+    private func updateLibraryTab() {
+        guard let libraryTab else { return }
+        let account = AccountStore.shared
+        guard account.isLoggedIn else {
+            libraryTab.updateSections([])
+            libraryTab.emptyViewTitleVariants = [String(localized: "请先登录网易云音乐")]
+            return
+        }
+        let model = CarPlayLibraryModel(
+            liked: account.likedSongsPlaylist,
+            created: Array(account.createdPlaylists.prefix(20)),
+            subscribed: Array(account.subscribedPlaylists.prefix(20)),
+            isLoggedIn: true
+        )
+        let sections = CarPlayTemplateFactory.librarySections(
+            library: model,
+            onEntryTap: { [weak self] entry in self?.pushLibraryEntry(entry, liked: model.liked) },
+            onPlaylistTap: { [weak self] playlist in self?.pushPlaylistDetail(playlist) }
+        )
+        libraryTab.updateSections(sections)
+        libraryTab.emptyViewTitleVariants = ["暂无内容"]
+    }
+
+    /// Tap handler for the four Library entries: pushes the tracks-list template, then renders it once tracks load.
+    private func pushLibraryEntry(_ entry: CarPlayLibraryEntry, liked: PlaylistSummary?) {
+        let loading = CPListTemplate(title: entry.title, sections: [])
+        loading.emptyViewTitleVariants = ["正在加载…"]
+
+        interfaceController?.pushTemplate(loading, animated: true) { [weak self] _, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                let tracks = await self.fetchTracks(for: entry, liked: liked)
+                guard !tracks.isEmpty else {
+                    loading.updateSections([])
+                    loading.emptyViewTitleVariants = ["暂无曲目"]
+                    return
+                }
+                let detail = CarPlayTemplateFactory.trackListTemplate(
+                    title: entry.title,
+                    trackCount: tracks.count,
+                    tracks: tracks,
+                    onPlayAll: { [weak self] in self?.handlePlayAll(entry: entry, liked: liked) },
+                    onTrackTap: { [weak self] track, allTracks in self?.handleTrackTap(entry: entry, track: track, allTracks: allTracks, liked: liked) }
+                )
+                loading.updateSections(detail.sections)
+            }
+        }
+    }
+
+    /// Fetches tracks for a given Library entry. An empty array means "no tracks" or "not logged in".
+    private func fetchTracks(for entry: CarPlayLibraryEntry, liked: PlaylistSummary?) async -> [Track] {
+        switch entry {
+        case .liked:
+            guard let liked else { return [] }
+            return await content.fetchPlaylistTracks(id: liked.id, name: liked.name)
+        case .daily:
+            await content.fetchDailyTracks(loggedIn: AccountStore.shared.isLoggedIn)
+            return content.dailyTracks
+        case .recents:
+            await content.fetchRecentsTracks(loggedIn: AccountStore.shared.isLoggedIn)
+            return content.recentsTracks
+        case .cloud:
+            await content.fetchCloudTracks(loggedIn: AccountStore.shared.isLoggedIn)
+            return content.cloudTracks
+        }
+    }
+
+    /// "Play all" handler: routes through `play(context:)` so PlayerService drives its full resolve + load flow.
+    private func handlePlayAll(entry: CarPlayLibraryEntry, liked: PlaylistSummary?) {
+        switch entry {
+        case .liked:
+            guard let liked else { return }
+            PlayerService.shared.play(context: .playlist(id: liked.id, name: liked.name))
+        case .daily:
+            PlayerService.shared.play(context: .daily)
+        case .recents:
+            PlayerService.shared.play(context: .recents)
+        case .cloud:
+            PlayerService.shared.play(context: .cloud)
+        }
+    }
+
+    /// Single-track tap handler: passes the full queue so next/prev stay useful.
+    private func handleTrackTap(entry: CarPlayLibraryEntry, track: Track, allTracks: [Track], liked: PlaylistSummary?) {
+        switch entry {
+        case .liked:
+            guard let liked else { return }
+            PlayerService.shared.play(
+                tracks: allTracks,
+                source: .playlist(liked.id),
+                startAt: track,
+                context: .playlist(id: liked.id, name: liked.name)
+            )
+        case .daily:
+            PlayerService.shared.play(
+                tracks: allTracks,
+                source: .daily,
+                startAt: track,
+                context: .daily
+            )
+        case .recents:
+            PlayerService.shared.play(
+                tracks: allTracks,
+                source: .none,
+                startAt: track,
+                context: .recents
+            )
+        case .cloud:
+            PlayerService.shared.play(
+                tracks: allTracks,
+                source: .cloud,
+                startAt: track,
+                context: .cloud
+            )
+        }
+    }
+
+    // MARK: - Radar / album / artist detail
+
+    /// Recommend tab radar tap: `radar.id` is itself a playlist id, so it goes straight through `fetchPlaylistTracks`.
+    private func pushRadarPlaylist(_ radar: CarPlayRadarPlaylist) {
+        pushTracks(
+            title: radar.title,
+            load: { [weak self] in
+                guard let self else { return nil }
+                return await self.content.fetchPlaylistTracks(id: radar.id, name: radar.title)
+            },
+            context: .playlist(id: radar.id, name: radar.title),
+            source: .playlist(radar.id)
+        )
+    }
+
+    /// Recommend tab album tap: fetch album details, play the whole album or one song.
+    private func pushAlbum(_ album: AlbumSummary) {
+        pushTracks(
+            title: album.name,
+            load: {
+                try? await NeteaseAPI.album(id: album.id).songs
+            },
+            context: .album(id: album.id, name: album.name),
+            source: .album(album.id)
+        )
+    }
+
+    /// Recommend tab artist tap: fetch the artist's hot tracks.
+    private func pushArtist(_ artist: ArtistSummary) {
+        pushTracks(
+            title: artist.name,
+            load: {
+                try? await NeteaseAPI.artist(id: artist.id).hotSongs
+            },
+            context: .artist(id: artist.id, name: artist.name),
+            source: .artist(artist.id)
+        )
+    }
+
+    /// Generic "push tracks" helper: shows an empty template first, then fills it with `trackListTemplate` once tracks load.
+    private func pushTracks(
+        title: String,
+        load: @escaping () async -> [Track]?,
+        context: PlayContext,
+        source: PlaySource
+    ) {
+        let loading = CPListTemplate(title: title, sections: [])
+        loading.emptyViewTitleVariants = ["正在加载…"]
+
+        interfaceController?.pushTemplate(loading, animated: true) { [weak self] _, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                guard let tracks = await load(), !tracks.isEmpty else {
+                    loading.updateSections([])
+                    loading.emptyViewTitleVariants = ["暂无曲目"]
+                    return
+                }
+                let detail = CarPlayTemplateFactory.trackListTemplate(
+                    title: title,
+                    trackCount: tracks.count,
+                    tracks: tracks,
+                    onPlayAll: { PlayerService.shared.play(context: context) },
+                    onTrackTap: { track, allTracks in
+                        PlayerService.shared.play(tracks: allTracks, source: source, startAt: track, context: context)
+                    }
+                )
+                loading.updateSections(detail.sections)
+            }
+        }
+    }
+
+    // MARK: - Playlist detail
+
+    /// Pushes the playlist detail template: empty template with title first, then populated once tracks load.
+    private func pushPlaylistDetail(_ playlist: PlaylistSummary) {
+        let loading = CPListTemplate(title: playlist.name, sections: [])
+        loading.emptyViewTitleVariants = ["正在加载…"]
+
+        interfaceController?.pushTemplate(loading, animated: true) { [weak self] _, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                let tracks = await self.content.fetchPlaylistTracks(
+                    id: playlist.id, name: playlist.name
+                )
+                let detail = CarPlayTemplateFactory.playlistDetailTemplate(
+                    playlist: playlist,
+                    tracks: tracks,
+                    onPlayAll: {
+                        // Play all: route through PlayerService.play(context:) so we reuse the full load + play pipeline.
+                        PlayerService.shared.play(context: .playlist(id: playlist.id, name: playlist.name))
+                    },
+                    onTrackTap: { track, allTracks in
+                        // Single track tap: hand over the entire queue so next/prev still work.
+                        PlayerService.shared.play(
+                            tracks: allTracks,
+                            source: .playlist(playlist.id),
+                            startAt: track,
+                            context: .playlist(id: playlist.id, name: playlist.name)
+                        )
+                    }
+                )
+                loading.updateSections(detail.sections)
+            }
+        }
+    }
+
+    /// Pushes the toplist detail template (toplists are just playlists under the hood).
+    private func pushToplistDetail(_ toplist: ToplistItem) {
+        let loading = CPListTemplate(title: toplist.name, sections: [])
+        loading.emptyViewTitleVariants = ["正在加载…"]
+
+        interfaceController?.pushTemplate(loading, animated: true) { [weak self] _, _ in
+            Task { @MainActor in
+                guard let self else { return }
+                // A toplist's id is just its playlist id.
+                let tracks = await self.content.fetchPlaylistTracks(
+                    id: toplist.id, name: toplist.name
+                )
+                let detail = CarPlayTemplateFactory.toplistDetailTemplate(
+                    toplist: toplist,
+                    tracks: tracks,
+                    onPlayAll: {
+                        PlayerService.shared.play(context: .playlist(id: toplist.id, name: toplist.name))
+                    },
+                    onTrackTap: { track, allTracks in
+                        PlayerService.shared.play(
+                            tracks: allTracks,
+                            source: .playlist(toplist.id),
+                            startAt: track,
+                            context: .playlist(id: toplist.id, name: toplist.name)
+                        )
+                    }
+                )
+                loading.updateSections(detail.sections)
+            }
+        }
+    }
+
+    // MARK: - Login-state rebuild
+
+    /// When the account changes, rebuild all tab data (forces a full cache refresh).
+    private func rebuildAllTabs() {
+        scheduleFullReload(bootstrapIfNeeded: false)
+    }
+
+    /// Library-tab-only refresh (fired when `userPlaylists` changes; doesn't trigger another network roundtrip).
+    private func refreshLibraryTab() {
+        Task { @MainActor in updateLibraryTab() }
+    }
+}
+#endif

--- a/Sources/Kumone/Core/CarPlay/CarPlayContentStore.swift
+++ b/Sources/Kumone/Core/CarPlay/CarPlayContentStore.swift
@@ -1,0 +1,210 @@
+// CarPlayContentStore.swift — CarPlay data loading layer.
+// Pure data logic with no CarPlay framework dependencies, so it can be unit tested standalone.
+
+#if os(iOS)
+import Foundation
+
+/// Backs the CarPlay templates with playlist / toplist / track data.
+/// Each fetcher has a built-in ~5-minute TTL so we don't pound the API on every tab switch.
+@MainActor
+final class CarPlayContentStore {
+
+    // MARK: - Cached data
+
+    private(set) var recommendPlaylists: [PlaylistSummary] = []
+    private(set) var highQualityPlaylists: [PlaylistSummary] = []
+    private(set) var hotPlaylists: [PlaylistSummary] = []
+    private(set) var officialPlaylists: [PlaylistSummary] = []
+    private(set) var chinesePlaylists: [PlaylistSummary] = []
+    private(set) var toplists: [ToplistItem] = []
+    private(set) var dailyTracks: [Track] = []
+    private(set) var recentsTracks: [Track] = []
+    private(set) var cloudTracks: [Track] = []
+    private(set) var radarPlaylists: [CarPlayRadarPlaylist] = []
+    private(set) var newAlbums: [AlbumSummary] = []
+    private(set) var topArtists: [ArtistSummary] = []
+
+    // MARK: - TTL management
+
+    /// Cache lifetime in seconds.
+    private let ttl: TimeInterval
+
+    private var recommendFetchedAt: Date = .distantPast
+    private var curatedFetchedAt: Date = .distantPast
+    private var officialFetchedAt: Date = .distantPast
+    private var chineseFetchedAt: Date = .distantPast
+    private var toplistsFetchedAt: Date = .distantPast
+    private var dailyFetchedAt: Date = .distantPast
+    private var recentsFetchedAt: Date = .distantPast
+    private var cloudFetchedAt: Date = .distantPast
+    private var radarFetchedAt: Date = .distantPast
+    private var albumsFetchedAt: Date = .distantPast
+    private var artistsFetchedAt: Date = .distantPast
+
+    /// Custom TTL constructor (defaults to 5 minutes; tests can pass a shorter value).
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    // MARK: - Recommend
+
+    /// Loads the Recommend tab's playlists. Login-aware behavior mirrors
+    /// `HomeViewModel.fetchRecommendPlaylists` exactly so the two stay in sync.
+    func fetchRecommendPlaylists(loggedIn: Bool, force: Bool = false) async {
+        // TTL check
+        if !force, Date().timeIntervalSince(recommendFetchedAt) < ttl, !recommendPlaylists.isEmpty { return }
+
+        if loggedIn {
+            async let recommend = try? NeteaseAPI.recommendResource()
+            async let personalized = try? NeteaseAPI.personalizedPlaylists(limit: 30)
+            let head = await recommend ?? []
+            let tail = await personalized ?? []
+            var seen = Set<Int>()
+            recommendPlaylists = (head + tail).filter { seen.insert($0.id).inserted }
+        } else {
+            recommendPlaylists = (try? await NeteaseAPI.personalizedPlaylists(limit: 30)) ?? []
+        }
+        recommendFetchedAt = Date()
+    }
+
+    // MARK: - Curated
+
+    /// Loads the Curated tab's two main buckets: high-quality and hot playlists.
+    func fetchCuratedPlaylists(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(curatedFetchedAt) < ttl,
+           !highQualityPlaylists.isEmpty, !hotPlaylists.isEmpty { return }
+
+        async let hq = (try? await NeteaseAPI.highQualityPlaylists(limit: 50))?.playlists ?? []
+        async let hot = (try? await NeteaseAPI.topPlaylists(category: "全部", limit: 50))?.playlists ?? []
+        highQualityPlaylists = await hq
+        hotPlaylists = await hot
+        curatedFetchedAt = Date()
+    }
+
+    // MARK: - Curated sub-categories (mirror App ExploreView's chips)
+
+    /// Official playlists — backs the "Official" chip in the App's Curated tab.
+    func fetchOfficialPlaylists(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(officialFetchedAt) < ttl, !officialPlaylists.isEmpty { return }
+        officialPlaylists = (try? await NeteaseAPI.topPlaylists(category: "官方", limit: 30))?.playlists ?? []
+        officialFetchedAt = Date()
+    }
+
+    /// Chinese playlists — backs the "Chinese" chip in the App's Curated tab.
+    func fetchChinesePlaylists(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(chineseFetchedAt) < ttl, !chinesePlaylists.isEmpty { return }
+        chinesePlaylists = (try? await NeteaseAPI.topPlaylists(category: "华语", limit: 30))?.playlists ?? []
+        chineseFetchedAt = Date()
+    }
+
+    // MARK: - Toplists
+
+    /// Loads the toplist (chart) list.
+    func fetchToplists(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(toplistsFetchedAt) < ttl, !toplists.isEmpty { return }
+
+        toplists = (try? await NeteaseAPI.toplists()) ?? []
+        toplistsFetchedAt = Date()
+    }
+
+    // MARK: - Daily recommend
+
+    /// Loads the daily-recommend tracks. Login-only — logged-out callers get an
+    /// empty array right away so we don't waste a request on a guaranteed 401.
+    func fetchDailyTracks(loggedIn: Bool, force: Bool = false) async {
+        guard loggedIn else { dailyTracks = []; return }
+        if !force, Date().timeIntervalSince(dailyFetchedAt) < ttl, !dailyTracks.isEmpty { return }
+        dailyTracks = (try? await NeteaseAPI.dailyRecommendSongs()) ?? []
+        dailyFetchedAt = Date()
+    }
+
+    // MARK: - Recently played
+
+    /// Loads the all-time recently-played tracks. We unwrap `.song` on each
+    /// `PlayRecordItem` so callers get a plain `[Track]`.
+    func fetchRecentsTracks(loggedIn: Bool, force: Bool = false) async {
+        guard loggedIn, let uid = AccountStore.shared.profile?.userId else {
+            recentsTracks = []
+            return
+        }
+        if !force, Date().timeIntervalSince(recentsFetchedAt) < ttl, !recentsTracks.isEmpty { return }
+        recentsTracks = (try? await NeteaseAPI.playRecords(uid: uid, week: false))?.map(\.song) ?? []
+        recentsFetchedAt = Date()
+    }
+
+    // MARK: - Cloud disk
+
+    /// Loads cloud-disk tracks, capped at 300 to match the upper bound that
+    /// `trackListTemplate` renders anyway (no point pulling more).
+    func fetchCloudTracks(loggedIn: Bool, force: Bool = false) async {
+        guard loggedIn else { cloudTracks = []; return }
+        if !force, Date().timeIntervalSince(cloudFetchedAt) < ttl, !cloudTracks.isEmpty { return }
+        cloudTracks = (try? await NeteaseAPI.cloudSongs(limit: 300, offset: 0))?
+            .data?.compactMap(\.simpleSong) ?? []
+        cloudFetchedAt = Date()
+    }
+
+    // MARK: - Radar playlists
+
+    /// Loads the four fixed-ID personalized radar playlists (login-only).
+    /// NetEase names the radar playlists in the form "<seed-track intro>|Personal Radar", so we split on `|`
+    /// to peel off the "Personal Radar" subtitle and keep the rest as the title.
+    func fetchRadarPlaylists(loggedIn: Bool, force: Bool = false) async {
+        guard loggedIn else { radarPlaylists = []; return }
+        if !force, Date().timeIntervalSince(radarFetchedAt) < ttl, !radarPlaylists.isEmpty { return }
+        let ids = CarPlayRadarPlaylist.ids
+        let briefs = await withTaskGroup(of: (Int, NeteaseAPI.PlaylistBrief.Body?).self) { group in
+            for id in ids {
+                group.addTask {
+                    (id, try? await NeteaseAPI.playlistBrief(id: id))
+                }
+            }
+            var byID: [Int: NeteaseAPI.PlaylistBrief.Body] = [:]
+            for await (id, brief) in group {
+                if let brief { byID[id] = brief }
+            }
+            return byID
+        }
+        radarPlaylists = ids.compactMap { id in
+            guard let brief = briefs[id] else { return nil }
+            let parts = (brief.name ?? "").components(separatedBy: "|")
+            let title = parts.count > 1 ? parts.last! : (brief.name ?? "雷达歌单")
+            let subtitle = parts.count > 1 ? parts.dropLast().joined(separator: "|") : nil
+            return CarPlayRadarPlaylist(id: id, title: title, subtitle: subtitle, coverURL: brief.coverImgUrl)
+        }
+        radarFetchedAt = Date()
+    }
+
+    // MARK: - New albums
+
+    /// Loads the latest albums (first 20).
+    func fetchNewAlbums(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(albumsFetchedAt) < ttl, !newAlbums.isEmpty { return }
+        newAlbums = (try? await NeteaseAPI.newAlbums(limit: 20)) ?? []
+        albumsFetchedAt = Date()
+    }
+
+    // MARK: - Top artists
+
+    /// Loads the trending artists and picks 6 at random. We shuffle so the
+    /// lineup changes between sessions, matching the App's HomeView which does
+    /// the same — otherwise the same faces show up every time the user opens CarPlay.
+    func fetchTopArtists(force: Bool = false) async {
+        if !force, Date().timeIntervalSince(artistsFetchedAt) < ttl, !topArtists.isEmpty { return }
+        let artists = (try? await NeteaseAPI.topArtists()) ?? []
+        topArtists = Array(artists.shuffled().prefix(6))
+        artistsFetchedAt = Date()
+    }
+
+    // MARK: - Playlist detail
+
+    /// Fetches the full track list for a playlist (with pagination baked into
+    /// `PlayerService.resolve`, so we just hand off to it).
+    func fetchPlaylistTracks(id: Int, name: String) async -> [Track] {
+        guard let resolved = try? await PlayerService.shared.resolve(
+            .playlist(id: id, name: name)
+        ) else { return [] }
+        return resolved.tracks
+    }
+}
+#endif

--- a/Sources/Kumone/Core/CarPlay/CarPlayTemplateFactory.swift
+++ b/Sources/Kumone/Core/CarPlay/CarPlayTemplateFactory.swift
@@ -1,0 +1,453 @@
+// CarPlayTemplateFactory.swift — Stateless CarPlay template builder.
+// Converts data models into CarPlay template elements, kept fully decoupled from data loading and lifecycle logic.
+
+#if os(iOS)
+import CarPlay
+import UIKit
+
+/// Stateless factory that builds CarPlay templates.
+enum CarPlayTemplateFactory {
+
+    // MARK: - Playlist row → CPListSection
+
+    /// Converts Recommend/Curated playlists into a CPListSection; tapping a row pushes the playlist detail.
+    /// `header` is optional — the Library tab's "Created Playlists" / "Subscribed Playlists" sections need a header.
+    static func playlistSections(
+        _ playlists: [PlaylistSummary],
+        onPlaylistTap: @escaping (PlaylistSummary) -> Void,
+        header: String? = nil
+    ) -> [CPListSection] {
+        let items = playlists.map { playlist -> CPListItem in
+            let item = CPListItem(text: playlist.name, detailText: playlist.playCount > 0 ? "\(formattedCount(playlist.playCount))次播放" : nil)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onPlaylistTap(playlist)
+                completion()
+            }
+            // Async-load the cover image; the row refreshes itself when it lands.
+            fillArtwork(item, from: playlist.coverURL)
+            return item
+        }
+        return [CPListSection(items: items, header: header, sectionIndexTitle: nil)]
+    }
+
+    // MARK: - Toplist row → CPListSection
+
+    /// Converts the toplist array into a CPListSection.
+    static func toplistSections(
+        _ items: [ToplistItem],
+        onToplistTap: @escaping (ToplistItem) -> Void
+    ) -> [CPListSection] {
+        let listItems = items.map { toplist -> CPListItem in
+            let item = CPListItem(text: toplist.name, detailText: toplist.updateFrequency)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onToplistTap(toplist)
+                completion()
+            }
+            fillArtwork(item, from: toplist.coverImgUrl)
+            return item
+        }
+        return [CPListSection(items: listItems)]
+    }
+
+    // MARK: - Playlist detail (track list)
+
+    /// Builds the playlist detail template: "Play All" row + track rows.
+    static func playlistDetailTemplate(
+        playlist: PlaylistSummary,
+        tracks: [Track],
+        onPlayAll: @escaping () -> Void,
+        onTrackTap: @escaping (Track, [Track]) -> Void
+    ) -> CPListTemplate {
+        return trackListTemplate(
+            title: playlist.name,
+            trackCount: tracks.count,
+            tracks: tracks,
+            onPlayAll: onPlayAll,
+            onTrackTap: onTrackTap
+        )
+    }
+
+    // MARK: - Toplist detail template
+
+    /// Toplist detail, built standalone (`PlaylistSummary` has no memberwise init, so we can't reuse the helper above).
+    static func toplistDetailTemplate(
+        toplist: ToplistItem,
+        tracks: [Track],
+        onPlayAll: @escaping () -> Void,
+        onTrackTap: @escaping (Track, [Track]) -> Void
+    ) -> CPListTemplate {
+        return trackListTemplate(
+            title: toplist.name,
+            trackCount: tracks.count,
+            tracks: tracks,
+            onPlayAll: onPlayAll,
+            onTrackTap: onTrackTap
+        )
+    }
+
+    // MARK: - Generic track-list template
+
+    /// Generic "Play All" + track rows builder. Kept internal so `CarPlayConnector.pushLibraryEntry` can reuse it.
+    static func trackListTemplate(
+        title: String,
+        trackCount: Int,
+        tracks: [Track],
+        onPlayAll: @escaping () -> Void,
+        onTrackTap: @escaping (Track, [Track]) -> Void
+    ) -> CPListTemplate {
+        let playAllItem = CPListItem(text: "播放全部 · \(trackCount) 首", detailText: nil)
+        playAllItem.accessoryType = .none
+        playAllItem.handler = { _, completion in
+            onPlayAll()
+            completion()
+        }
+
+        let cappedTracks = Array(tracks.prefix(300))
+        let trackItems = cappedTracks.map { track -> CPListItem in
+            let item = CPListItem(text: track.name, detailText: track.artistNames)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onTrackTap(track, tracks)
+                completion()
+            }
+            return item
+        }
+
+        let sections = [
+            CPListSection(items: [playAllItem]),
+            CPListSection(items: trackItems),
+        ]
+        let template = CPListTemplate(title: title, sections: sections)
+        template.emptyViewTitleVariants = ["暂无曲目"]
+        return template
+    }
+
+    // MARK: - Async artwork loading
+
+    /// Async-loads the cover image into a `CPListItem` and refreshes the row once it lands.
+    static func fillArtwork(_ item: CPListItem, from coverURL: String?) {
+        guard let urlStr = coverURL, let url = urlStr.resizedImageURL(120) else { return }
+        Task { @MainActor in
+            guard let image = await ImageCache.shared.image(for: url) else { return }
+            item.setImage(image)
+        }
+    }
+
+    // MARK: - Formatting
+
+    /// Compact play-count formatter that returns Chinese-locale units when the count is large enough; smaller values are returned as a plain integer.
+    private static func formattedCount(_ count: Int) -> String {
+        if count >= 100_000_000 { return "\(count / 100_000_000)亿" }
+        if count >= 10_000 { return "\(Double(count) / 10_000, default: "%.1f")万" }
+        return "\(count)"
+    }
+}
+
+// MARK: - FM tab
+
+extension CarPlayTemplateFactory {
+    /// Builds the sections for the FM (Roaming) tab.
+    ///
+    /// When FM mode is off we just show a single "Start Roaming" button to kick
+    /// things off. When FM mode is on we lead with the currently playing track
+    /// (assuming we already have one loaded) so the driver can see at a glance
+    /// what they're listening to — that's the "Now Roaming" row. If FM is on but
+    /// the first track hasn't loaded yet (we're still talking to NetEase),
+    /// we drop in a small "Preparing roaming…" placeholder so the tab doesn't look
+    /// broken in the meantime.
+    ///
+    /// Below the track row sits the action button, which does double duty:
+    /// while playing it reads "Next" and jumps to the next recommendation,
+    /// and while paused (but with a loaded track) it reads "Resume Roaming" and
+    /// resumes from the same spot via `togglePlayPause`.
+    static func fmSection(
+        isFMMode: Bool,
+        isPlaying: Bool,
+        currentTrack: Track?,
+        onActionTap: @escaping () -> Void
+    ) -> [CPListSection] {
+        var sections: [CPListSection] = []
+
+        // The currently playing track — purely informational. Tapping it is a
+        // no-op because CarPlay's system Now Playing template already shows
+        // the song with full transport controls.
+        if isFMMode {
+            if let track = currentTrack {
+                let trackItem = CPListItem(text: track.name, detailText: track.artistNames)
+                trackItem.accessoryType = .none
+                trackItem.setImage(UIImage(systemName: "dot.radiowaves.left.and.right"))
+                trackItem.handler = { _, completion in
+                    completion()
+                }
+                sections.append(CPListSection(
+                    items: [trackItem],
+                    header: "正在漫游",
+                    sectionIndexTitle: nil
+                ))
+            } else {
+                let placeholder = CPListItem(text: "正在准备漫游…", detailText: nil)
+                placeholder.accessoryType = .none
+                placeholder.handler = { _, completion in completion() }
+                sections.append(CPListSection(
+                    items: [placeholder],
+                    header: "正在漫游",
+                    sectionIndexTitle: nil
+                ))
+            }
+        }
+
+        // The action button section — one row that changes its label and icon
+        // depending on whether FM is on and whether we're playing.
+        let actionItem: CPListItem
+        if isFMMode {
+            actionItem = CPListItem(
+                text: isPlaying ? "换一首" : "继续漫游",
+                detailText: nil
+            )
+            actionItem.setImage(UIImage(systemName: isPlaying ? "forward.fill" : "play.fill"))
+        } else {
+            actionItem = CPListItem(
+                text: "开始漫游",
+                detailText: "根据你的口味生成连续推荐"
+            )
+            actionItem.setImage(UIImage(systemName: "dot.radiowaves.left.and.right"))
+        }
+        actionItem.accessoryType = .none
+        actionItem.handler = { _, completion in
+            onActionTap()
+            completion()
+        }
+        sections.append(CPListSection(items: [actionItem]))
+
+        return sections
+    }
+}
+
+// MARK: - Library tab
+
+/// Data snapshot for the Library tab — the caller assembles it from `AccountStore` and passes it to the factory.
+struct CarPlayLibraryModel {
+    let liked: PlaylistSummary?
+    let created: [PlaylistSummary]
+    let subscribed: [PlaylistSummary]
+    let isLoggedIn: Bool
+}
+
+/// Four sub-entries under the "My Music" section, matching the App's IOSLibraryView.
+enum CarPlayLibraryEntry {
+    case liked, daily, recents, cloud
+
+    var title: String {
+        switch self {
+        case .liked: return "我喜欢的音乐"
+        case .daily: return "每日推荐"
+        case .recents: return "最近播放"
+        case .cloud: return "音乐云盘"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .liked: return "heart.fill"
+        case .daily: return "calendar"
+        case .recents: return "clock.fill"
+        case .cloud: return "icloud.fill"
+        }
+    }
+}
+
+extension CarPlayTemplateFactory {
+    /// Builds the Library tab's sections: My Music + Created Playlists + Subscribed Playlists.
+    /// Returns `[]` when logged out — the caller is responsible for showing the empty view.
+    static func librarySections(
+        library: CarPlayLibraryModel,
+        onEntryTap: @escaping (CarPlayLibraryEntry) -> Void,
+        onPlaylistTap: @escaping (PlaylistSummary) -> Void
+    ) -> [CPListSection] {
+        guard library.isLoggedIn else { return [] }
+
+        var myMusicItems: [CPListItem] = []
+        if library.liked != nil {
+            myMusicItems.append(makeEntryItem(.liked, onTap: onEntryTap))
+        }
+        myMusicItems.append(makeEntryItem(.daily, onTap: onEntryTap))
+        myMusicItems.append(makeEntryItem(.recents, onTap: onEntryTap))
+        myMusicItems.append(makeEntryItem(.cloud, onTap: onEntryTap))
+
+        var sections: [CPListSection] = [
+            CPListSection(items: myMusicItems, header: "我的音乐", sectionIndexTitle: nil)
+        ]
+
+        if !library.created.isEmpty {
+            sections.append(contentsOf: playlistSections(
+                library.created,
+                onPlaylistTap: onPlaylistTap,
+                header: "创建的歌单"
+            ))
+        }
+
+        if !library.subscribed.isEmpty {
+            sections.append(contentsOf: playlistSections(
+                library.subscribed,
+                onPlaylistTap: onPlaylistTap,
+                header: "收藏的歌单"
+            ))
+        }
+
+        return sections
+    }
+
+    /// Single sub-menu item (no cover, just an SF Symbol).
+    private static func makeEntryItem(
+        _ entry: CarPlayLibraryEntry,
+        onTap: @escaping (CarPlayLibraryEntry) -> Void
+    ) -> CPListItem {
+        let item = CPListItem(text: entry.title, detailText: nil)
+        item.accessoryType = .none
+        item.setImage(UIImage(systemName: entry.icon))
+        item.handler = { _, completion in
+            onTap(entry)
+            completion()
+        }
+        return item
+    }
+}
+
+// MARK: - Recommend tab feature cards
+
+/// Three feature entries in the "Today's Picks" section, matching App HomeView's FeatureCard.
+enum CarPlayRecommendFeature {
+    case daily, fm, heartbeat
+
+    var title: String {
+        switch self {
+        case .daily: return "每日推荐"
+        case .fm: return "私人漫游"
+        case .heartbeat: return "心动模式"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .daily: return "根据你的口味生成"
+        case .fm: return "从喜欢的歌开始漫游"
+        case .heartbeat: return "你的红心歌曲和相似推荐"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .daily: return "calendar"
+        case .fm: return "wave.3.right.circle.fill"
+        case .heartbeat: return "heart.circle.fill"
+        }
+    }
+}
+
+// MARK: - Radar playlists / new albums / recommended artists
+
+/// Snapshot of the personalized radar playlists; mirrors `HomeView.RadarPlaylist` 1:1.
+struct CarPlayRadarPlaylist: Identifiable, Hashable {
+    let id: Int
+    let title: String
+    let subtitle: String?
+    let coverURL: String?
+
+    /// Must stay in sync with `HomeViewModel.radarPlaylistIDs`.
+    static let ids: [Int] = [
+        3_136_952_023, // Personal radar
+        2_829_883_282, // Chinese radar
+        2_829_816_518, // Western radar
+        2_829_896_389, // Japanese radar
+    ]
+}
+
+extension CarPlayTemplateFactory {
+    /// The "Today's Picks" section at the top of the Recommend tab — three feature entry rows.
+    /// Only shown when logged in; the caller skips this section otherwise.
+    static func recommendFeatureSections(
+        onTap: @escaping (CarPlayRecommendFeature) -> Void
+    ) -> [CPListSection] {
+        let items = [
+            makeFeatureItem(.daily, onTap: onTap),
+            makeFeatureItem(.fm, onTap: onTap),
+            makeFeatureItem(.heartbeat, onTap: onTap),
+        ]
+        return [CPListSection(items: items, header: "今日推荐", sectionIndexTitle: nil)]
+    }
+
+    private static func makeFeatureItem(
+        _ feature: CarPlayRecommendFeature,
+        onTap: @escaping (CarPlayRecommendFeature) -> Void
+    ) -> CPListItem {
+        let item = CPListItem(text: feature.title, detailText: feature.detail)
+        item.accessoryType = .none
+        item.setImage(UIImage(systemName: feature.icon))
+        item.handler = { _, completion in
+            onTap(feature)
+            completion()
+        }
+        return item
+    }
+}
+
+// MARK: - Radar / new album / top artist sections
+
+extension CarPlayTemplateFactory {
+    /// Radar playlist section: one `CPListItem` per radar (with cover), tapping opens the playlist detail.
+    static func radarPlaylistSections(
+        _ radars: [CarPlayRadarPlaylist],
+        onTap: @escaping (CarPlayRadarPlaylist) -> Void
+    ) -> [CPListSection] {
+        let items = radars.map { radar -> CPListItem in
+            let item = CPListItem(text: radar.title, detailText: radar.subtitle)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onTap(radar)
+                completion()
+            }
+            fillArtwork(item, from: radar.coverURL)
+            return item
+        }
+        return [CPListSection(items: items, header: "雷达歌单", sectionIndexTitle: nil)]
+    }
+
+    /// New albums section.
+    static func newAlbumSections(
+        _ albums: [AlbumSummary],
+        onTap: @escaping (AlbumSummary) -> Void
+    ) -> [CPListSection] {
+        let items = albums.map { album -> CPListItem in
+            let item = CPListItem(text: album.name, detailText: album.artistName)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onTap(album)
+                completion()
+            }
+            fillArtwork(item, from: album.picUrl)
+            return item
+        }
+        return [CPListSection(items: items, header: "新碟上架", sectionIndexTitle: nil)]
+    }
+
+    /// Recommended artists section — no cover image, only the circular avatar placeholder that CPListItem renders by default.
+    static func topArtistSections(
+        _ artists: [ArtistSummary],
+        onTap: @escaping (ArtistSummary) -> Void
+    ) -> [CPListSection] {
+        let items = artists.map { artist -> CPListItem in
+            let item = CPListItem(text: artist.name, detailText: nil)
+            item.accessoryType = .none
+            item.handler = { _, completion in
+                onTap(artist)
+                completion()
+            }
+            fillArtwork(item, from: artist.picUrl)
+            return item
+        }
+        return [CPListSection(items: items, header: "推荐歌手", sectionIndexTitle: nil)]
+    }
+}
+#endif

--- a/Sources/Kumone/Core/Player/NowPlayingManager.swift
+++ b/Sources/Kumone/Core/Player/NowPlayingManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import MediaPlayer
 
@@ -8,12 +9,14 @@ final class NowPlayingManager {
 
     private weak var player: PlayerService?
     private var artworkTask: Task<Void, Never>?
+    private var playbackStateCancellables: Set<AnyCancellable> = []
     private var info: [String: Any] = [:]
 
     private init() {}
 
     func attach(to player: PlayerService) {
         self.player = player
+        playbackStateCancellables.removeAll()
         let center = MPRemoteCommandCenter.shared()
 
         center.playCommand.addTarget { [weak player] _ in
@@ -57,6 +60,60 @@ final class NowPlayingManager {
             }
             return .success
         }
+
+        // Skip forward/backward — backs the ±15s buttons on the CarPlay Now Playing screen.
+        center.skipForwardCommand.preferredIntervals = [15]
+        center.skipForwardCommand.addTarget { [weak player] _ in
+            guard let player else { return .commandFailed }
+            player.seek(to: player.progress + 15)
+            return .success
+        }
+        center.skipBackwardCommand.preferredIntervals = [15]
+        center.skipBackwardCommand.addTarget { [weak player] _ in
+            guard let player else { return .commandFailed }
+            player.seek(to: max(0, player.progress - 15))
+            return .success
+        }
+
+        // Shuffle / Repeat — backs the shuffle and repeat buttons on the CarPlay Now Playing screen.
+        center.changeShuffleModeCommand.addTarget { [weak player] event in
+            guard let player,
+                  let event = event as? MPChangeShuffleModeCommandEvent else { return .commandFailed }
+            let wantOn = event.shuffleType != .off
+            if player.shuffleEnabled != wantOn { player.toggleShuffle() }
+            return .success
+        }
+        center.changeRepeatModeCommand.addTarget { [weak player] event in
+            guard let player,
+                  let event = event as? MPChangeRepeatModeCommandEvent else { return .commandFailed }
+            // MPRepeatType: .off / .one / .all → RepeatMode: .off / .one / .all
+            let target: RepeatMode? = switch event.repeatType {
+                case .off:  .off
+                case .one:  .one
+                case .all:  .all
+                default:    nil
+            }
+            if let target, player.repeatMode != target { player.repeatMode = target }
+            return .success
+        }
+
+        player.$shuffleEnabled
+            .removeDuplicates()
+            .sink { enabled in
+                center.changeShuffleModeCommand.currentShuffleType = enabled ? .items : .off
+            }
+            .store(in: &playbackStateCancellables)
+
+        player.$repeatMode
+            .removeDuplicates()
+            .sink { mode in
+                center.changeRepeatModeCommand.currentRepeatType = switch mode {
+                case .off: .off
+                case .one: .one
+                case .all: .all
+                }
+            }
+            .store(in: &playbackStateCancellables)
     }
 
     /// Reflects the current track's hearted state on the like command.

--- a/Sources/Kumone/Core/Player/PlayerService.swift
+++ b/Sources/Kumone/Core/Player/PlayerService.swift
@@ -189,7 +189,7 @@ final class PlayerService: ObservableObject {
 
         #if os(iOS)
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, policy: .longFormAudio, options: [])
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             print("Failed to activate audio session: \(error)")
@@ -742,7 +742,7 @@ final class PlayerService: ObservableObject {
         }
     }
 
-    private func resolve(_ context: PlayContext) async throws -> (tracks: [Track], source: PlaySource)? {
+    func resolve(_ context: PlayContext) async throws -> (tracks: [Track], source: PlaySource)? {
         switch context.kind {
         case .fm:
             return nil

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -13,5 +13,24 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
     </dict>
+    <key>UISupportsCarPlay</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>CPTemplateApplicationSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>CarPlay</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/ios/Config/KumoneIOS.entitlements
+++ b/ios/Config/KumoneIOS.entitlements
@@ -30,5 +30,18 @@
 	</array>
     
 	-->
+
+	<!--
+		CarPlay 音频能力需要 Apple 单独授权（提交 CarPlay 申请），未授权时真机编译会报：
+		"Entitlement com.apple.developer.carplay-audio not found and could not be included in profile"。
+		默认保持注释；如需启用 CarPlay：
+		1. 在 Apple Developer 后台为你的 App ID 开通 CarPlay (Audio) 能力
+		2. 取消下面这段注释并重新签名
+		3. 同时把 ios/Config/Info.plist 里的 CarPlay 相关键保持开启
+	-->
+	<!--
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
+	-->
 </dict>
 </plist>

--- a/ios/Config/KumoneIOS.entitlements.example
+++ b/ios/Config/KumoneIOS.entitlements.example
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+	CarPlay 音频能力示例 entitlements。
+
+	默认的 KumoneIOS.entitlements 不包含 CarPlay capability，
+	因为它需要 Apple 单独授权，未授权的真机会在签名时报：
+	  "Entitlement com.apple.developer.carplay-audio not found and could not be included in profile."
+
+	如果你已通过 Apple CarPlay 申请并获得授权，按下列步骤启用：
+
+	1. 在 Apple Developer 后台为你的 App ID 勾选 CarPlay (Audio) capability
+	   https://developer.apple.com/account/resources/certificates/list
+	2. 重新生成/下载 provisioning profile
+	3. 把下方 <!-- ... --> 取消注释，替换或合并到 KumoneIOS.entitlements
+	4. 在 Xcode → Signing & Capabilities 确认 CarPlay (Audio) 已勾选
+	5. 重新 clean + build (Cmd + Shift + K, Cmd + Shift + B)
+-->
+<plist version="1.0">
+<dict>
+	<!--
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
+	-->
+</dict>
+</plist>

--- a/ios/KumoneIOS.xcodeproj/project.pbxproj
+++ b/ios/KumoneIOS.xcodeproj/project.pbxproj
@@ -24,11 +24,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0646F456C7BF38C0A8ED880E /* KumoneIOSUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KumoneIOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0646F456C7BF38C0A8ED880E /* KumoneIOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KumoneIOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2199D32FC69383EC32B19794 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		25934AD73710C9EDB53BDDA0 /* KumoneIOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = KumoneIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		45602F996F250E88035F23A9 /* KumoneIOSPackage */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KumoneIOSPackage; path = KumoneIOSPackage; sourceTree = SOURCE_ROOT; };
-		66554F47F0D6FC82F2EFDB2A /* KumoneIOS.xctestplan */ = {isa = PBXFileReference; path = KumoneIOS.xctestplan; sourceTree = "<group>"; };
+		25934AD73710C9EDB53BDDA0 /* KumoneIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KumoneIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		45602F996F250E88035F23A9 /* KumoneIOSPackage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = KumoneIOSPackage; sourceTree = SOURCE_ROOT; };
+		66554F47F0D6FC82F2EFDB2A /* KumoneIOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = KumoneIOS.xctestplan; sourceTree = "<group>"; };
 		6D28AAA402747474C3A1B8AD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		74C59F0F113B18EBEA9C55B6 /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
 		7A9033A23C5610F19ABA3774 /* KumoneIOSUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KumoneIOSUITests.swift; sourceTree = "<group>"; };
@@ -71,7 +71,7 @@
 			isa = PBXGroup;
 			children = (
 				25934AD73710C9EDB53BDDA0 /* KumoneIOS.app */,
-				0646F456C7BF38C0A8ED880E /* KumoneIOSUITests.xctest */,
+				0646F456C7BF38C0A8ED880E /* KumoneIOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -142,7 +142,7 @@
 			packageProductDependencies = (
 			);
 			productName = KumoneIOSUITests;
-			productReference = 0646F456C7BF38C0A8ED880E /* KumoneIOSUITests.xctest */;
+			productReference = 0646F456C7BF38C0A8ED880E /* KumoneIOS.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
@@ -155,7 +155,6 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					481C5C62EB4A6DB3CC0FDC39 = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					7F3FA2EAD87A1580A6CD3880 = {
@@ -316,6 +315,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Config/KumoneIOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 9ZGVJ862WJ;
 				ENABLE_PREVIEWS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -394,6 +394,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Config/KumoneIOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = M2DXV97G43;
 				ENABLE_PREVIEWS = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/KumoneIOS.xcodeproj/xcshareddata/xcschemes/KumoneIOS.xcscheme
+++ b/ios/KumoneIOS.xcodeproj/xcshareddata/xcschemes/KumoneIOS.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -40,19 +38,16 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F3FA2EAD87A1580A6CD3880"
-               BuildableName = "KumoneIOSUITests.xctest"
+               BuildableName = "KumoneIOS.xctest"
                BlueprintName = "KumoneIOSUITests"
                ReferencedContainer = "container:KumoneIOS.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -74,8 +69,6 @@
             ReferencedContainer = "container:KumoneIOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ios/KumoneIOS/KumoneIOSApp.swift
+++ b/ios/KumoneIOS/KumoneIOSApp.swift
@@ -9,3 +9,32 @@ struct KumoneIOSApp: App {
         }
     }
 }
+
+// MARK: - CarPlay
+
+import CarPlay
+import UIKit
+
+/// CarPlay template scene delegate — instantiated automatically by UIApplicationSceneManifest in Info.plist.
+/// It just forwards the connect/disconnect callbacks into `CarPlayConnector` inside KumoneCore;
+/// the app target itself stays as a thin bridge and owns no CarPlay logic of its own.
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {}
+
+extension CarPlaySceneDelegate {
+    func templateApplicationScene(
+        _ scene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        CarPlayConnector.shared.didConnect(
+            interfaceController: interfaceController,
+            window: scene.carWindow
+        )
+    }
+
+    func templateApplicationScene(
+        _ scene: CPTemplateApplicationScene,
+        didDisconnect interfaceController: CPInterfaceController
+    ) {
+        CarPlayConnector.shared.didDisconnect()
+    }
+}

--- a/ios/KumoneIOSPackage/Package.resolved
+++ b/ios/KumoneIOSPackage/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "45f213d2a4df59b2943f9f6d868988cd92481625c190c918533fc8da92c39b97",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
- 新增 Sources/Kumone/Core/CarPlay/ 三件套：Connector / ContentStore / TemplateFactory，完整镜像 App 主界面 4 个 Tab（推荐 / 精选 / 漫游 / 我的）
- NowPlayingManager 接通 ±15s / shuffle / repeat / like / trash 系统媒体控制（同时驱动 iOS 锁屏、控制中心与 CarPlay Now Playing）
- PlayerService 音频会话策略改为 .longFormAudio，resolve() 改为 internal 供 CarPlayContentStore 调用
- Info.plist 声明 UISupportsCarPlay + CarPlay scene 配置
- ios/Config/KumoneIOS.entitlements 默认注释 com.apple.developer.carplay-audio（Apple CarPlay 音频 能力需单独授权，未授权打开会导致真机签名失败）
- 新增 ios/Config/KumoneIOS.entitlements.example 模板
- README / README_CN / CHANGELOG 同步启用说明