### PR TITLE
feat(recommendation): add reduce recommendation action

### DIFF
--- a/Sources/Kumone/Core/API/NeteaseAPI.swift
+++ b/Sources/Kumone/Core/API/NeteaseAPI.swift
@@ -248,6 +248,36 @@ enum NeteaseAPI {
         return resp.data?.dailySongs ?? []
     }
 
+    struct RecommendDislikeResponse: Decodable {
+        let data: Track
+
+        private enum CodingKeys: String, CodingKey {
+            case data
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let track = try container.decode(Track.self, forKey: .data)
+            guard track.id > 0,
+                  !track.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .data,
+                    in: container,
+                    debugDescription: "Recommendation replacement is incomplete"
+                )
+            }
+            data = track
+        }
+    }
+
+    static func dislikeRecommendedSong(id: Int) async throws -> Track {
+        try await weapi(
+            RecommendDislikeResponse.self,
+            "/v2/discovery/recommend/dislike",
+            ["resId": id, "resType": 4, "sceneType": 1]
+        ).data
+    }
+
     struct PlaylistDetailResponse: Decodable {
         let playlist: PlaylistDetail
         let privileges: [TrackPrivilege]?

--- a/Sources/Kumone/Core/Models/Track.swift
+++ b/Sources/Kumone/Core/Models/Track.swift
@@ -153,3 +153,14 @@ extension Track {
         return .playable
     }
 }
+
+extension Array where Element == Track {
+    @discardableResult
+    mutating func replaceRecommendation(_ rejected: Track, with replacement: Track) -> Bool {
+        guard let index = firstIndex(where: { $0.id == rejected.id }),
+              replacement.id != rejected.id,
+              !contains(where: { $0.id == replacement.id }) else { return false }
+        self[index] = replacement
+        return true
+    }
+}

--- a/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
+++ b/Sources/Kumone/Features/Detail/PlaylistDetailView.swift
@@ -10,6 +10,7 @@ final class PlaylistDetailViewModel: ObservableObject {
     @Published var isLoadingMore = false
     @Published var errorMessage: String?
     @Published var filter = ""
+    private var reducedRecommendationIDs: Set<Int> = []
 
     init(playlistID: Int) {
         self.playlistID = playlistID
@@ -31,7 +32,7 @@ final class PlaylistDetailViewModel: ObservableObject {
         do {
             let response = try await NeteaseAPI.playlistDetail(id: playlistID)
             detail = response.playlist
-            tracks = response.playlist.tracks
+            tracks = response.playlist.tracks.filter { !reducedRecommendationIDs.contains($0.id) }
             merge(privileges: response.privileges)
             isLoading = false
             await loadRemainingTracks()
@@ -49,7 +50,7 @@ final class PlaylistDetailViewModel: ObservableObject {
         for chunk in stride(from: 0, to: remaining.count, by: 500)
             .map({ Array(remaining.dropFirst($0).prefix(500)) }) {
             guard let response = try? await NeteaseAPI.songDetails(ids: chunk) else { break }
-            tracks += response.songs
+            tracks += response.songs.filter { !reducedRecommendationIDs.contains($0.id) }
             merge(privileges: response.privileges)
         }
     }
@@ -63,11 +64,18 @@ final class PlaylistDetailViewModel: ObservableObject {
     func remove(_ track: Track) {
         tracks.removeAll { $0.id == track.id }
     }
+
+    func replaceRecommendation(_ rejected: Track, with replacement: Track) {
+        if tracks.replaceRecommendation(rejected, with: replacement) {
+            reducedRecommendationIDs.insert(rejected.id)
+        }
+    }
 }
 
 struct PlaylistDetailView: View {
     let playlistID: Int
     var isLikedList = false
+    var recommendationContext: RecommendationContext?
 
     @StateObject private var model: PlaylistDetailViewModel
     @EnvironmentObject private var player: PlayerService
@@ -75,9 +83,10 @@ struct PlaylistDetailView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showFullDescription = false
 
-    init(playlistID: Int, isLikedList: Bool = false) {
+    init(playlistID: Int, isLikedList: Bool = false, recommendationContext: RecommendationContext? = nil) {
         self.playlistID = playlistID
         self.isLikedList = isLikedList
+        self.recommendationContext = recommendationContext
         _model = StateObject(wrappedValue: PlaylistDetailViewModel(playlistID: playlistID))
     }
 
@@ -113,7 +122,9 @@ struct PlaylistDetailView: View {
                         source: .playlist(playlistID),
                         context: model.detail.map { .playlist(id: playlistID, name: $0.name) },
                         removableFromPlaylistID: isOwnPlaylist ? playlistID : nil,
-                        onRemoved: { model.remove($0) }
+                        onRemoved: { model.remove($0) },
+                        recommendationContext: recommendationContext,
+                        onRecommendationReduced: { model.replaceRecommendation($0, with: $1) }
                     )
                     .padding(.horizontal, isCompact ? 6 : Theme.Layout.contentInset - 10)
 

--- a/Sources/Kumone/Features/Home/HomeView.swift
+++ b/Sources/Kumone/Features/Home/HomeView.swift
@@ -164,7 +164,7 @@ struct HomeView: View {
             if !model.radarPlaylists.isEmpty {
                 Shelf(title: "雷达歌单", rowHeight: Theme.Layout.coverShelfHeight) {
                     ForEach(model.radarPlaylists) { radar in
-                        NavigationLink(value: Destination.playlist(radar.id)) {
+                        NavigationLink(value: Destination.radarPlaylist(radar.id)) {
                             CoverCardBody(
                                 coverURL: radar.coverURL?.resizedImageURL(384),
                                 title: radar.title,

--- a/Sources/Kumone/Features/Navigation.swift
+++ b/Sources/Kumone/Features/Navigation.swift
@@ -61,6 +61,7 @@ enum SidebarItem: Hashable {
 
 enum Destination: Hashable {
     case playlist(Int)
+    case radarPlaylist(Int)
     case album(Int)
     case artist(Int)
     case daily
@@ -79,6 +80,8 @@ struct DestinationsModifier: ViewModifier {
                 switch destination {
                 case .playlist(let id):
                     PlaylistDetailView(playlistID: id)
+                case .radarPlaylist(let id):
+                    PlaylistDetailView(playlistID: id, recommendationContext: .radar)
                 case .album(let id):
                     AlbumDetailView(albumID: id)
                 case .artist(let id):

--- a/Sources/Kumone/Features/Pages/DailySongsView.swift
+++ b/Sources/Kumone/Features/Pages/DailySongsView.swift
@@ -28,7 +28,15 @@ struct DailySongsView: View {
                                    subtitle: "多听几首歌培养口味，每天 6:00 更新")
                         .frame(minHeight: 300)
                 } else {
-                    TrackListView(tracks: tracks, source: .daily, context: .daily)
+                    TrackListView(
+                        tracks: tracks,
+                        source: .daily,
+                        context: .daily,
+                        recommendationContext: .daily,
+                        onRecommendationReduced: { rejected, replacement in
+                            tracks.replaceRecommendation(rejected, with: replacement)
+                        }
+                    )
                         .padding(.horizontal, Theme.Layout.contentInset - 10)
                 }
                 PlayerClearanceSpacer()

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -9,6 +9,11 @@ enum TrackRowStyle {
     case compact
 }
 
+enum RecommendationContext {
+    case daily
+    case radar
+}
+
 // MARK: - Row
 
 struct TrackRow: View {
@@ -21,6 +26,7 @@ struct TrackRow: View {
     /// Set when the row lives inside a user's own playlist (enables 删除).
     var removableFromPlaylistID: Int?
     var onRemoved: (() -> Void)?
+    var onRecommendationReduced: ((Track) -> Void)?
     let onPlay: () -> Void
 
     @EnvironmentObject private var player: PlayerService
@@ -31,6 +37,7 @@ struct TrackRow: View {
     @ScaledMetric(relativeTo: .body) private var compactAlbumRowHeight: CGFloat = 50
     @State private var isHovering = false
     @State private var showAddToPlaylist = false
+    @State private var isReducingRecommendation = false
 
     private var isCurrent: Bool { player.currentTrack?.id == track.id }
     private var isPlayable: Bool { playability == .playable }
@@ -242,6 +249,25 @@ struct TrackRow: View {
                 }
             }
         }
+        #if os(macOS)
+        if !account.isLiked(track.id), let onRecommendationReduced {
+            Button(String(localized: "减少推荐"), role: .destructive) {
+                guard !isReducingRecommendation else { return }
+                isReducingRecommendation = true
+                Task {
+                    defer { isReducingRecommendation = false }
+                    do {
+                        let replacement = try await NeteaseAPI.dislikeRecommendedSong(id: track.id)
+                        onRecommendationReduced(replacement)
+                        ToastCenter.shared.show(String(localized: "已减少推荐"))
+                    } catch {
+                        ToastCenter.shared.show(error.localizedDescription)
+                    }
+                }
+            }
+            .disabled(isReducingRecommendation)
+        }
+        #endif
         Divider()
         if track.album.id > 0 {
             NavigationLink(value: Destination.album(track.album.id)) {
@@ -456,6 +482,8 @@ struct TrackListView: View {
     var context: PlayContext?
     var removableFromPlaylistID: Int?
     var onRemoved: ((Track) -> Void)?
+    var recommendationContext: RecommendationContext?
+    var onRecommendationReduced: ((Track, Track) -> Void)?
 
     @EnvironmentObject private var player: PlayerService
     @EnvironmentObject private var account: AccountStore
@@ -463,13 +491,17 @@ struct TrackListView: View {
     var body: some View {
         LazyVStack(spacing: 1) {
             ForEach(Array(tracks.enumerated()), id: \.element.id) { index, track in
+                let recommendationHandler = onRecommendationReduced
                 TrackRow(
                     track: track,
                     index: style == .albumTrack ? (track.trackNo > 0 ? track.trackNo : index + 1) : index + 1,
                     style: style,
                     playability: playability(of: track),
                     removableFromPlaylistID: removableFromPlaylistID,
-                    onRemoved: { onRemoved?(track) }
+                    onRemoved: { onRemoved?(track) },
+                    onRecommendationReduced: recommendationContext == nil || recommendationHandler == nil
+                        ? nil
+                        : { replacement in recommendationHandler?(track, replacement) }
                 ) {
                     player.play(tracks: playableTracks, source: source, startAt: track,
                                 context: context)

--- a/Sources/Kumone/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kumone/Resources/en.lproj/Localizable.strings
@@ -149,6 +149,8 @@
 "多听几首歌培养口味，每天 6:00 更新" = "Listen to more songs to build your taste — refreshes daily at 6:00";
 "根据你的音乐口味 · 每天 6:00 更新" = "Based on your taste · Refreshes daily at 6:00";
 "登录后才能查看每日推荐" = "Sign in to see daily recommendations";
+"减少推荐" = "Recommend less";
+"已减少推荐" = "Recommendation reduced";
 "登录后查看你喜欢的音乐" = "Sign in to see your liked songs";
 
 /* Search */

--- a/Tests/KumoneCoreTests/RecommendationTests.swift
+++ b/Tests/KumoneCoreTests/RecommendationTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import KumoneCore
+
+@Suite("Recommendation Tests")
+struct RecommendationTests {
+    @Test func decodesReplacementTrack() throws {
+        let response = try JSONDecoder().decode(
+            NeteaseAPI.RecommendDislikeResponse.self,
+            from: Data("""
+            {"data":{"id":2,"name":"Replacement","ar":[],"al":{"id":1,"name":"Album"},"dt":1}}
+            """.utf8)
+        )
+
+        #expect(response.data.id == 2)
+        #expect(response.data.name == "Replacement")
+    }
+
+    @Test func rejectsIncompleteReplacementTrack() {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(
+                NeteaseAPI.RecommendDislikeResponse.self,
+                from: Data("""
+                {"data":{"id":0,"name":" ","ar":[],"al":{"id":1,"name":"Album"},"dt":1}}
+                """.utf8)
+            )
+        }
+    }
+
+    @Test func replacementPreservesListIdentity() throws {
+        let first = try track(id: 1)
+        let rejected = try track(id: 2)
+        let replacement = try track(id: 3)
+        var tracks = [first, rejected]
+
+        tracks.replaceRecommendation(rejected, with: replacement)
+
+        #expect(tracks.map(\.id) == [1, 3])
+    }
+
+    @Test func duplicateReplacementPreservesRejectedTrack() throws {
+        let existing = try track(id: 1)
+        let rejected = try track(id: 2)
+        var tracks = [existing, rejected]
+
+        tracks.replaceRecommendation(rejected, with: existing)
+
+        #expect(tracks.map(\.id) == [1, 2])
+    }
+
+    private func track(id: Int) throws -> Track {
+        try JSONDecoder().decode(
+            Track.self,
+            from: Data("""
+            {"id":\(id),"name":"Track \(id)","ar":[],"al":{"id":1,"name":"Album"},"dt":1}
+            """.utf8)
+        )
+    }
+}


### PR DESCRIPTION
# 每日推荐和私人雷达歌单新增「减少推荐」功能

每日推荐和私人雷达歌单里的歌曲，目前只能播放或执行已有的歌曲操作，无法直接告诉 NetEase“少推荐这首”。

这个 PR 在 macOS 的歌曲右键菜单中加入“减少推荐”。请求成功后，服务端返回一首替代歌曲，列表原位置直接替换；返回数据不完整或替代歌曲会造成重复时，保留原歌曲。

Closes #74

## 具体做了什么

### 调用推荐反馈接口

新增 `NeteaseAPI.dislikeRecommendedSong(id:)`，调用实际使用的接口：

```text
/weapi/v2/discovery/recommend/dislike
```

请求参数为：

| 参数 | 值 |
|---|---|
| `resId` | 被减少推荐的歌曲 ID |
| `resType` | `4`，表示歌曲 |
| `sceneType` | `1` |

接口返回的 `data` 会解码为替代歌曲。替代歌曲必须同时满足以下条件，否则认为响应无效：

- ID 大于 0
- 歌曲名去除首尾空白后不为空

### 在歌曲右键菜单中增加操作

`TrackRow` 在 macOS 下增加“减少推荐”菜单项，但只有满足以下条件时才显示：

- 当前列表明确声明了推荐场景
- 列表提供了替换回调
- 当前歌曲没有被用户收藏

请求进行中会禁用菜单项，避免重复提交。请求失败时保留原歌曲，并通过现有 Toast 显示错误。

### 替换列表中的歌曲

新增 `Array<Track>.replaceRecommendation(_:with:)`，负责检查替换结果：

- 只替换 ID 匹配的被拒绝歌曲
- 替代歌曲不能与被拒绝歌曲使用相同 ID
- 替代歌曲不能与列表中的其他歌曲重复
- 任一条件不满足时，原歌曲保持不变

### 处理私人雷达歌单

私人雷达歌单现在通过独立的 `Destination.radarPlaylist` 进入详情页，并携带 `.radar` 推荐上下文，避免从普通歌单名称推断推荐类型。

`PlaylistDetailViewModel` 会记录已经成功替换的歌曲 ID，并在以下场景中过滤它们：

- 首次加载歌单
- 加载剩余歌曲
- 分页加载更多歌曲

这样重新加载或继续分页时，被减少推荐的歌曲不会再次出现。

### 每日推荐

每日推荐列表接入同一套推荐上下文和替换回调。替换成功后只更新对应行，不需要重新加载整个页面。

### 本地化

增加以下英文文案：

- `Reduce Recommendation`
- `Recommendation reduced`

## 测试

新增 Swift Testing 覆盖：

- 正常替代歌曲响应的解码
- ID 无效或歌曲名为空时拒绝响应
- 正常替换歌曲并保留列表顺序
- 替代歌曲 ID 重复时保留原歌曲

```text
swift test
git diff --check
plutil -lint Sources/Kumone/Resources/en.lproj/Localizable.strings
```

## 请重点验证

- 每日推荐中右键歌曲，选择“减少推荐”后，原位置是否替换为服务端返回的歌曲。
- 请求进行时是否不能重复点击。
- 接口失败时，原歌曲是否仍然存在并显示错误提示。
- 私人雷达歌单是否显示同一菜单项。
- 减少推荐后重新加载或继续分页，被处理的歌曲是否不会再次出现。
- 已收藏歌曲是否不显示“减少推荐”。
- 普通歌单是否仍保持原有导航和歌曲操作行为。

## 范围说明

本次改动只接入每日推荐和私人雷达两个推荐列表场景，复用现有歌曲列表、Toast 和 NetEase 请求层，不改变普通歌单的推荐行为或现有“从歌单移除”操作。