### PR TITLE
feat(macos): add main window artwork ambient background

### DIFF
--- a/Sources/Kumone/Core/Storage/SettingsManager.swift
+++ b/Sources/Kumone/Core/Storage/SettingsManager.swift
@@ -105,6 +105,10 @@ final class SettingsManager: ObservableObject {
         static let autoCheckUpdates = "settings.autoCheckUpdates"
         static let desktopLyrics = "settings.showDesktopLyrics"
         static let desktopLyricsCentered = "settings.desktopLyricsCentered"
+        #if os(macOS)
+        static let mainWindowAmbientBackground = "settings.showMainWindowAmbientBackground"
+        static let mainWindowAmbientBackgroundIntensity = "settings.mainWindowAmbientBackgroundIntensity"
+        #endif
     }
 
     @Published var audioQuality: AudioQuality {
@@ -162,6 +166,30 @@ final class SettingsManager: ObservableObject {
         didSet { UserDefaults.standard.set(desktopLyricsCentered, forKey: Keys.desktopLyricsCentered) }
     }
 
+    #if os(macOS)
+    static let mainWindowAmbientBackgroundIntensityRange = 0.5...1.5
+
+    /// Artwork-tinted overlay on the main desktop window.
+    @Published var showMainWindowAmbientBackground: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                showMainWindowAmbientBackground,
+                forKey: Keys.mainWindowAmbientBackground
+            )
+        }
+    }
+
+    /// Multiplier applied to the main window's artwork tint.
+    @Published var mainWindowAmbientBackgroundIntensity: Double {
+        didSet {
+            UserDefaults.standard.set(
+                mainWindowAmbientBackgroundIntensity,
+                forKey: Keys.mainWindowAmbientBackgroundIntensity
+            )
+        }
+    }
+    #endif
+
     private init() {
         let defaults = UserDefaults.standard
         audioQuality = defaults.string(forKey: Keys.quality).flatMap(AudioQuality.init) ?? .exhigh
@@ -176,5 +204,17 @@ final class SettingsManager: ObservableObject {
         autoCheckUpdates = defaults.object(forKey: Keys.autoCheckUpdates) as? Bool ?? true
         showDesktopLyrics = defaults.object(forKey: Keys.desktopLyrics) as? Bool ?? false
         desktopLyricsCentered = defaults.object(forKey: Keys.desktopLyricsCentered) as? Bool ?? false
+        #if os(macOS)
+        showMainWindowAmbientBackground = defaults.object(
+            forKey: Keys.mainWindowAmbientBackground
+        ) as? Bool ?? true
+        let storedAmbientBackgroundIntensity = defaults.object(
+            forKey: Keys.mainWindowAmbientBackgroundIntensity
+        ) as? Double ?? 1
+        mainWindowAmbientBackgroundIntensity = min(
+            max(storedAmbientBackgroundIntensity, Self.mainWindowAmbientBackgroundIntensityRange.lowerBound),
+            Self.mainWindowAmbientBackgroundIntensityRange.upperBound
+        )
+        #endif
     }
 }

--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -9,6 +9,9 @@ struct MainWindow: View {
     @EnvironmentObject private var settings: SettingsManager
     @EnvironmentObject private var toasts: ToastCenter
 
+    #if os(macOS)
+    @StateObject private var artworkStore = NowPlayingArtworkStore()
+    #endif
     @State private var selection: SidebarItem = .home
     @State private var path = NavigationPath()
     @State private var showLogin = false
@@ -29,19 +32,21 @@ struct MainWindow: View {
                 }
         }
         .navigationSplitViewStyle(.balanced)
+        #if os(macOS)
+        .overlay(alignment: .trailing) {
+            if settings.showMainWindowAmbientBackground, detailWidth > 0 {
+                MainWindowAmbientBackground(
+                    colors: artworkStore.colors,
+                    intensity: settings.mainWindowAmbientBackgroundIntensity
+                )
+                    .frame(width: detailWidth)
+            }
+        }
+        #endif
         .toolbar {
-            if #available(macOS 26.0, iOS 26.0, *) {
-                ToolbarItem(placement: .primaryAction) {
-                    SearchFieldView { query in
-                        path.append(Destination.search(query))
-                    }
-                }
-                .sharedBackgroundVisibility(.hidden)
-            } else {
-                ToolbarItem(placement: .primaryAction) {
-                    SearchFieldView { query in
-                        path.append(Destination.search(query))
-                    }
+            ToolbarItem(placement: .primaryAction) {
+                SearchFieldView { query in
+                    path.append(Destination.search(query))
                 }
             }
         }
@@ -51,10 +56,21 @@ struct MainWindow: View {
         .toolbar(player.showNowPlaying ? .hidden : .automatic, for: .windowToolbar)
         // Keep the single main window alive on Cmd+W / red button so the Dock
         // icon can always bring it back (#60/#63/#66/#70).
-        .background(MainWindowConfigurator())
+        .background(
+            MainWindowConfigurator(
+                showsAmbientBackground: settings.showMainWindowAmbientBackground,
+                showsTitlebarAmbientBackground: !player.showNowPlaying,
+                colors: artworkStore.colors,
+                mainColumnWidth: detailWidth,
+                intensity: settings.mainWindowAmbientBackgroundIntensity
+            )
+        )
         #endif
         .playerChrome(detailWidth: detailWidth)
         .environment(\.openLogin, { showLogin = true })
+        #if os(macOS)
+        .environmentObject(artworkStore)
+        #endif
         .task {
 #if os(macOS)
             // Keep this action in the app delegate: when the user closes the
@@ -85,8 +101,14 @@ struct MainWindow: View {
         }
         .overlay {
             if player.showNowPlaying {
+                #if os(macOS)
+                NowPlayingView()
+                    .environmentObject(artworkStore)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                #else
                 NowPlayingView()
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                #endif
             }
         }
         .overlay(alignment: .top) {
@@ -173,22 +195,54 @@ struct MainWindow: View {
 /// can front it again on a Dock click. Every other window-delegate callback is
 /// forwarded untouched to SwiftUI's own delegate.
 struct MainWindowConfigurator: NSViewRepresentable {
+    let showsAmbientBackground: Bool
+    let showsTitlebarAmbientBackground: Bool
+    let colors: ArtworkColors
+    let mainColumnWidth: CGFloat
+    let intensity: Double
+
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        DispatchQueue.main.async { context.coordinator.attach(to: view.window) }
+        DispatchQueue.main.async {
+            context.coordinator.attach(to: view.window)
+            context.coordinator.configureAmbientBackground(
+                showsAmbientBackground,
+                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
+                colors: colors,
+                mainColumnWidth: mainColumnWidth,
+                intensity: intensity
+            )
+        }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { context.coordinator.attach(to: nsView.window) }
+        DispatchQueue.main.async {
+            context.coordinator.attach(to: nsView.window)
+            context.coordinator.configureAmbientBackground(
+                showsAmbientBackground,
+                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
+                colors: colors,
+                mainColumnWidth: mainColumnWidth,
+                intensity: intensity
+            )
+        }
     }
 
     @MainActor
     final class Coordinator: NSObject, NSWindowDelegate {
         private(set) weak var window: NSWindow?
         private weak var forwardee: NSWindowDelegate?
+        private var showsAmbientBackground = false
+        private var showsTitlebarAmbientBackground = false
+        private var titlebarWasTransparent: Bool?
+        private var hadFullSizeContentView = false
+        private var colors: ArtworkColors = .fallback
+        private var mainColumnWidth: CGFloat = 0
+        private var intensity: Double = 1
+        private var titlebarMask: TitlebarMaskView?
 
         func attach(to window: NSWindow?) {
             guard let window, self.window == nil else { return }
@@ -201,6 +255,107 @@ struct MainWindowConfigurator: NSViewRepresentable {
                 window.delegate = self
             }
             AppDelegate.shared?.mainWindow = window
+        }
+
+        func configureAmbientBackground(
+            _ showsAmbientBackground: Bool,
+            showsTitlebarAmbientBackground: Bool,
+            colors: ArtworkColors,
+            mainColumnWidth: CGFloat,
+            intensity: Double
+        ) {
+            self.showsTitlebarAmbientBackground = showsTitlebarAmbientBackground
+            self.colors = colors
+            self.mainColumnWidth = mainColumnWidth
+            self.intensity = intensity
+            guard let window else { return }
+
+            guard self.showsAmbientBackground != showsAmbientBackground else {
+                applyAmbientWindowAppearance()
+                return
+            }
+            self.showsAmbientBackground = showsAmbientBackground
+
+            if showsAmbientBackground {
+                titlebarWasTransparent = window.titlebarAppearsTransparent
+                hadFullSizeContentView = window.styleMask.contains(.fullSizeContentView)
+                applyAmbientWindowAppearance()
+            } else {
+                window.titlebarAppearsTransparent = titlebarWasTransparent ?? false
+                if hadFullSizeContentView {
+                    window.styleMask.insert(.fullSizeContentView)
+                } else {
+                    window.styleMask.remove(.fullSizeContentView)
+                }
+                titlebarWasTransparent = nil
+                removeTitlebarMask()
+            }
+        }
+
+        func windowDidUpdate(_ notification: Notification) {
+            applyAmbientWindowAppearance()
+            forwardee?.windowDidUpdate?(notification)
+        }
+
+        private func applyAmbientWindowAppearance() {
+            guard showsAmbientBackground, let window else { return }
+            if !window.titlebarAppearsTransparent {
+                window.titlebarAppearsTransparent = true
+            }
+            if !window.styleMask.contains(.fullSizeContentView) {
+                window.styleMask.insert(.fullSizeContentView)
+            }
+            guard showsTitlebarAmbientBackground else {
+                removeTitlebarMask()
+                return
+            }
+            installTitlebarMask(in: window)
+            layoutTitlebarMask(in: window)
+        }
+
+        private func installTitlebarMask(in window: NSWindow) {
+            guard titlebarMask == nil, let contentView = window.contentView else { return }
+            let mask = TitlebarMaskView()
+            contentView.addSubview(mask, positioned: .above, relativeTo: nil)
+            titlebarMask = mask
+        }
+
+        private func layoutTitlebarMask(in window: NSWindow) {
+            guard let mask = titlebarMask, let contentView = window.contentView else { return }
+            let width = min(max(mainColumnWidth, 0), contentView.bounds.width)
+            guard width > 0 else {
+                mask.isHidden = true
+                return
+            }
+
+            let layoutRect = window.contentLayoutRect
+            let titlebarHeight = contentView.bounds.height - layoutRect.height
+            guard titlebarHeight > 0 else {
+                mask.isHidden = true
+                return
+            }
+            let y = contentView.isFlipped
+                ? contentView.bounds.minY
+                : contentView.bounds.maxY - titlebarHeight
+            let frame = CGRect(
+                x: contentView.bounds.maxX - width,
+                y: y,
+                width: width,
+                height: titlebarHeight
+            )
+
+            mask.frame = frame
+            mask.isHidden = false
+            mask.update(
+                colors: colors,
+                appearance: window.effectiveAppearance,
+                intensity: intensity
+            )
+        }
+
+        private func removeTitlebarMask() {
+            titlebarMask?.removeFromSuperview()
+            titlebarMask = nil
         }
 
         // Hide instead of close; keep the scene alive.
@@ -218,6 +373,56 @@ struct MainWindowConfigurator: NSViewRepresentable {
             if forwardee?.responds(to: aSelector) == true { return forwardee }
             return super.forwardingTarget(for: aSelector)
         }
+    }
+}
+
+private final class TitlebarMaskView: NSView {
+    private let gradientLayer = CAGradientLayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.addSublayer(gradientLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    override func layout() {
+        super.layout()
+        gradientLayer.frame = bounds
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    func update(colors: ArtworkColors, appearance: NSAppearance, intensity: Double) {
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let opacity = CGFloat(
+            MainWindowAmbientOpacity.gradient(isDark: isDark, intensity: intensity)
+        )
+        let base = NSColor.windowBackgroundColor
+        let primary = blended(NSColor(colors.primary), over: base, opacity: opacity)
+        let secondary = blended(NSColor(colors.secondary), over: base, opacity: opacity)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(Platform.isReduceMotionEnabled)
+        CATransaction.setAnimationDuration(0.6)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+        gradientLayer.colors = [primary.cgColor, secondary.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 1)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0)
+        CATransaction.commit()
+    }
+
+    private func blended(_ color: NSColor, over base: NSColor, opacity: CGFloat) -> NSColor {
+        let foreground = color.usingColorSpace(.extendedSRGB) ?? color
+        let background = base.usingColorSpace(.extendedSRGB) ?? base
+        return NSColor(
+            red: background.redComponent + (foreground.redComponent - background.redComponent) * opacity,
+            green: background.greenComponent + (foreground.greenComponent - background.greenComponent) * opacity,
+            blue: background.blueComponent + (foreground.blueComponent - background.blueComponent) * opacity,
+            alpha: 1
+        )
     }
 }
 #endif

--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -58,11 +58,13 @@ struct MainWindow: View {
         // icon can always bring it back (#60/#63/#66/#70).
         .background(
             MainWindowConfigurator(
-                showsAmbientBackground: settings.showMainWindowAmbientBackground,
-                showsTitlebarAmbientBackground: !player.showNowPlaying,
-                colors: artworkStore.colors,
-                mainColumnWidth: detailWidth,
-                intensity: settings.mainWindowAmbientBackgroundIntensity
+                ambientConfiguration: MainWindowAmbientConfiguration(
+                    showsAmbientBackground: settings.showMainWindowAmbientBackground,
+                    showsTitlebarAmbientBackground: !player.showNowPlaying,
+                    colors: artworkStore.colors,
+                    mainColumnWidth: detailWidth,
+                    intensity: settings.mainWindowAmbientBackgroundIntensity
+                )
             )
         )
         #endif
@@ -77,9 +79,7 @@ struct MainWindow: View {
             // last WindowGroup window, there is no view left to receive a
             // Dock reopen event directly.
             AppDelegate.shared?.openMainWindow = { openWindow(id: "main") }
-            artworkStore.setArtworkNeeded(
-                settings.showMainWindowAmbientBackground || player.showNowPlaying
-            )
+            artworkStore.setArtworkNeeded(needsCurrentArtwork)
 #endif
             DesktopLyricsController.shared.sync(with: settings.showDesktopLyrics)
             await account.bootstrap()
@@ -89,9 +89,7 @@ struct MainWindow: View {
         }
         #if os(macOS)
         .onChange(of: settings.showMainWindowAmbientBackground) { _ in
-            artworkStore.setArtworkNeeded(
-                settings.showMainWindowAmbientBackground || player.showNowPlaying
-            )
+            artworkStore.setArtworkNeeded(needsCurrentArtwork)
         }
         #endif
         // Collapse the sidebar while the immersive page is open: the split
@@ -99,9 +97,7 @@ struct MainWindow: View {
         // an overlay, leaking the drag cursor onto the now-playing page (#6).
         .onChange(of: player.showNowPlaying) { _ in
             #if os(macOS)
-            artworkStore.setArtworkNeeded(
-                settings.showMainWindowAmbientBackground || player.showNowPlaying
-            )
+            artworkStore.setArtworkNeeded(needsCurrentArtwork)
             #endif
             if player.showNowPlaying {
                 visibilityBeforeNowPlaying = columnVisibility
@@ -197,6 +193,11 @@ struct MainWindow: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    #if os(macOS)
+    private var needsCurrentArtwork: Bool {
+        settings.showMainWindowAmbientBackground || player.showNowPlaying
+    }
+    #endif
 }
 
 #if os(macOS)
@@ -210,11 +211,7 @@ struct MainWindow: View {
 /// can front it again on a Dock click. Every other window-delegate callback is
 /// forwarded untouched to SwiftUI's own delegate.
 struct MainWindowConfigurator: NSViewRepresentable {
-    let showsAmbientBackground: Bool
-    let showsTitlebarAmbientBackground: Bool
-    let colors: ArtworkColors
-    let mainColumnWidth: CGFloat
-    let intensity: Double
+    let ambientConfiguration: MainWindowAmbientConfiguration
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -223,11 +220,7 @@ struct MainWindowConfigurator: NSViewRepresentable {
         DispatchQueue.main.async {
             context.coordinator.requestAmbientBackgroundConfiguration(
                 from: view,
-                showsAmbientBackground: showsAmbientBackground,
-                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
-                colors: colors,
-                mainColumnWidth: mainColumnWidth,
-                intensity: intensity
+                ambientConfiguration: ambientConfiguration
             )
         }
         return view
@@ -237,11 +230,7 @@ struct MainWindowConfigurator: NSViewRepresentable {
         DispatchQueue.main.async {
             context.coordinator.requestAmbientBackgroundConfiguration(
                 from: nsView,
-                showsAmbientBackground: showsAmbientBackground,
-                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
-                colors: colors,
-                mainColumnWidth: mainColumnWidth,
-                intensity: intensity
+                ambientConfiguration: ambientConfiguration
             )
         }
     }
@@ -250,25 +239,10 @@ struct MainWindowConfigurator: NSViewRepresentable {
     final class Coordinator: NSObject, NSWindowDelegate {
         private(set) weak var window: NSWindow?
         private weak var forwardee: NSWindowDelegate?
-        private var showsAmbientBackground = false
-        private var showsTitlebarAmbientBackground = false
-        private var titlebarWasTransparent: Bool?
-        private var hadFullSizeContentView = false
-        private var colors: ArtworkColors = .fallback
-        private var mainColumnWidth: CGFloat = 0
-        private var intensity: Double = 1
-        private var titlebarMask: TitlebarMaskView?
+        private let ambientAppearance = MainWindowAmbientAppearanceController()
         private weak var configurationHost: NSView?
-        private var pendingAmbientConfiguration: AmbientConfiguration?
+        private var pendingAmbientConfiguration: MainWindowAmbientConfiguration?
         private var hasScheduledAmbientConfiguration = false
-
-        private struct AmbientConfiguration {
-            let showsAmbientBackground: Bool
-            let showsTitlebarAmbientBackground: Bool
-            let colors: ArtworkColors
-            let mainColumnWidth: CGFloat
-            let intensity: Double
-        }
 
         func attach(to window: NSWindow?) {
             guard let window, self.window == nil else { return }
@@ -285,20 +259,10 @@ struct MainWindowConfigurator: NSViewRepresentable {
 
         func requestAmbientBackgroundConfiguration(
             from host: NSView,
-            showsAmbientBackground: Bool,
-            showsTitlebarAmbientBackground: Bool,
-            colors: ArtworkColors,
-            mainColumnWidth: CGFloat,
-            intensity: Double
+            ambientConfiguration: MainWindowAmbientConfiguration
         ) {
             configurationHost = host
-            pendingAmbientConfiguration = AmbientConfiguration(
-                showsAmbientBackground: showsAmbientBackground,
-                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
-                colors: colors,
-                mainColumnWidth: mainColumnWidth,
-                intensity: intensity
-            )
+            pendingAmbientConfiguration = ambientConfiguration
             guard !hasScheduledAmbientConfiguration else { return }
             hasScheduledAmbientConfiguration = true
 
@@ -308,119 +272,16 @@ struct MainWindowConfigurator: NSViewRepresentable {
                 guard let configuration = self.pendingAmbientConfiguration else { return }
                 self.pendingAmbientConfiguration = nil
                 self.attach(to: self.configurationHost?.window)
-                self.configureAmbientBackground(
-                    configuration.showsAmbientBackground,
-                    showsTitlebarAmbientBackground: configuration.showsTitlebarAmbientBackground,
-                    colors: configuration.colors,
-                    mainColumnWidth: configuration.mainColumnWidth,
-                    intensity: configuration.intensity
-                )
-            }
-        }
-
-        func configureAmbientBackground(
-            _ showsAmbientBackground: Bool,
-            showsTitlebarAmbientBackground: Bool,
-            colors: ArtworkColors,
-            mainColumnWidth: CGFloat,
-            intensity: Double
-        ) {
-            self.showsTitlebarAmbientBackground = showsTitlebarAmbientBackground
-            self.colors = colors
-            self.mainColumnWidth = mainColumnWidth
-            self.intensity = intensity
-            guard let window else { return }
-
-            guard self.showsAmbientBackground != showsAmbientBackground else {
-                applyAmbientWindowAppearance()
-                return
-            }
-            self.showsAmbientBackground = showsAmbientBackground
-
-            if showsAmbientBackground {
-                titlebarWasTransparent = window.titlebarAppearsTransparent
-                hadFullSizeContentView = window.styleMask.contains(.fullSizeContentView)
-                applyAmbientWindowAppearance()
-            } else {
-                window.titlebarAppearsTransparent = titlebarWasTransparent ?? false
-                if hadFullSizeContentView {
-                    window.styleMask.insert(.fullSizeContentView)
-                } else {
-                    window.styleMask.remove(.fullSizeContentView)
-                }
-                titlebarWasTransparent = nil
-                removeTitlebarMask()
+                guard let window = self.window else { return }
+                self.ambientAppearance.configure(configuration, in: window)
             }
         }
 
         func windowDidUpdate(_ notification: Notification) {
-            applyAmbientWindowAppearance()
+            if let window {
+                ambientAppearance.updateLayout(in: window)
+            }
             forwardee?.windowDidUpdate?(notification)
-        }
-
-        private func applyAmbientWindowAppearance() {
-            guard showsAmbientBackground, let window else { return }
-            if !window.titlebarAppearsTransparent {
-                window.titlebarAppearsTransparent = true
-            }
-            if !window.styleMask.contains(.fullSizeContentView) {
-                window.styleMask.insert(.fullSizeContentView)
-            }
-            guard showsTitlebarAmbientBackground else {
-                removeTitlebarMask()
-                return
-            }
-            installTitlebarMask(in: window)
-            layoutTitlebarMask(in: window)
-        }
-
-        private func installTitlebarMask(in window: NSWindow) {
-            guard titlebarMask == nil, let contentView = window.contentView else { return }
-            let mask = TitlebarMaskView()
-            contentView.addSubview(mask, positioned: .above, relativeTo: nil)
-            titlebarMask = mask
-        }
-
-        private func layoutTitlebarMask(in window: NSWindow) {
-            guard let mask = titlebarMask, let contentView = window.contentView else { return }
-            let width = min(max(mainColumnWidth, 0), contentView.bounds.width)
-            guard width > 0 else {
-                mask.isHidden = true
-                return
-            }
-
-            let layoutRect = window.contentLayoutRect
-            let titlebarHeight = contentView.bounds.height - layoutRect.height
-            guard titlebarHeight > 0 else {
-                mask.isHidden = true
-                return
-            }
-            let y = contentView.isFlipped
-                ? contentView.bounds.minY
-                : contentView.bounds.maxY - titlebarHeight
-            let frame = CGRect(
-                x: contentView.bounds.maxX - width,
-                y: y,
-                width: width,
-                height: titlebarHeight
-            )
-
-            if mask.frame != frame {
-                mask.frame = frame
-            }
-            if mask.isHidden {
-                mask.isHidden = false
-            }
-            mask.update(
-                colors: colors,
-                appearance: window.effectiveAppearance,
-                intensity: intensity
-            )
-        }
-
-        private func removeTitlebarMask() {
-            titlebarMask?.removeFromSuperview()
-            titlebarMask = nil
         }
 
         // Hide instead of close; keep the scene alive.
@@ -438,68 +299,6 @@ struct MainWindowConfigurator: NSViewRepresentable {
             if forwardee?.responds(to: aSelector) == true { return forwardee }
             return super.forwardingTarget(for: aSelector)
         }
-    }
-}
-
-private final class TitlebarMaskView: NSView {
-    private let gradientLayer = CAGradientLayer()
-    private var appliedColors: ArtworkColors?
-    private var appliedAppearanceName: NSAppearance.Name?
-    private var appliedIntensity: Double?
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.addSublayer(gradientLayer)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
-
-    override func layout() {
-        super.layout()
-        gradientLayer.frame = bounds
-    }
-
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-
-    func update(colors: ArtworkColors, appearance: NSAppearance, intensity: Double) {
-        guard appliedColors != colors
-                || appliedAppearanceName != appearance.name
-                || appliedIntensity != intensity else {
-            return
-        }
-        appliedColors = colors
-        appliedAppearanceName = appearance.name
-        appliedIntensity = intensity
-
-        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        let opacity = CGFloat(
-            MainWindowAmbientOpacity.gradient(isDark: isDark, intensity: intensity)
-        )
-        let base = NSColor.windowBackgroundColor
-        let primary = blended(NSColor(colors.primary), over: base, opacity: opacity)
-        let secondary = blended(NSColor(colors.secondary), over: base, opacity: opacity)
-
-        CATransaction.begin()
-        CATransaction.setDisableActions(Platform.isReduceMotionEnabled)
-        CATransaction.setAnimationDuration(0.6)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
-        gradientLayer.colors = [primary.cgColor, secondary.cgColor]
-        gradientLayer.startPoint = CGPoint(x: 0, y: 1)
-        gradientLayer.endPoint = CGPoint(x: 1, y: 0)
-        CATransaction.commit()
-    }
-
-    private func blended(_ color: NSColor, over base: NSColor, opacity: CGFloat) -> NSColor {
-        let foreground = color.usingColorSpace(.extendedSRGB) ?? color
-        let background = base.usingColorSpace(.extendedSRGB) ?? base
-        return NSColor(
-            red: background.redComponent + (foreground.redComponent - background.redComponent) * opacity,
-            green: background.greenComponent + (foreground.greenComponent - background.greenComponent) * opacity,
-            blue: background.blueComponent + (foreground.blueComponent - background.blueComponent) * opacity,
-            alpha: 1
-        )
     }
 }
 #endif

--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -77,6 +77,9 @@ struct MainWindow: View {
             // last WindowGroup window, there is no view left to receive a
             // Dock reopen event directly.
             AppDelegate.shared?.openMainWindow = { openWindow(id: "main") }
+            artworkStore.setArtworkNeeded(
+                settings.showMainWindowAmbientBackground || player.showNowPlaying
+            )
 #endif
             DesktopLyricsController.shared.sync(with: settings.showDesktopLyrics)
             await account.bootstrap()
@@ -84,10 +87,22 @@ struct MainWindow: View {
         .onChange(of: settings.showDesktopLyrics) { _ in
             DesktopLyricsController.shared.sync(with: settings.showDesktopLyrics)
         }
+        #if os(macOS)
+        .onChange(of: settings.showMainWindowAmbientBackground) { _ in
+            artworkStore.setArtworkNeeded(
+                settings.showMainWindowAmbientBackground || player.showNowPlaying
+            )
+        }
+        #endif
         // Collapse the sidebar while the immersive page is open: the split
         // view's divider keeps its resize-cursor rect active even underneath
         // an overlay, leaking the drag cursor onto the now-playing page (#6).
         .onChange(of: player.showNowPlaying) { _ in
+            #if os(macOS)
+            artworkStore.setArtworkNeeded(
+                settings.showMainWindowAmbientBackground || player.showNowPlaying
+            )
+            #endif
             if player.showNowPlaying {
                 visibilityBeforeNowPlaying = columnVisibility
                 columnVisibility = .detailOnly
@@ -206,9 +221,9 @@ struct MainWindowConfigurator: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         DispatchQueue.main.async {
-            context.coordinator.attach(to: view.window)
-            context.coordinator.configureAmbientBackground(
-                showsAmbientBackground,
+            context.coordinator.requestAmbientBackgroundConfiguration(
+                from: view,
+                showsAmbientBackground: showsAmbientBackground,
                 showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
                 colors: colors,
                 mainColumnWidth: mainColumnWidth,
@@ -220,9 +235,9 @@ struct MainWindowConfigurator: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         DispatchQueue.main.async {
-            context.coordinator.attach(to: nsView.window)
-            context.coordinator.configureAmbientBackground(
-                showsAmbientBackground,
+            context.coordinator.requestAmbientBackgroundConfiguration(
+                from: nsView,
+                showsAmbientBackground: showsAmbientBackground,
                 showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
                 colors: colors,
                 mainColumnWidth: mainColumnWidth,
@@ -243,6 +258,17 @@ struct MainWindowConfigurator: NSViewRepresentable {
         private var mainColumnWidth: CGFloat = 0
         private var intensity: Double = 1
         private var titlebarMask: TitlebarMaskView?
+        private weak var configurationHost: NSView?
+        private var pendingAmbientConfiguration: AmbientConfiguration?
+        private var hasScheduledAmbientConfiguration = false
+
+        private struct AmbientConfiguration {
+            let showsAmbientBackground: Bool
+            let showsTitlebarAmbientBackground: Bool
+            let colors: ArtworkColors
+            let mainColumnWidth: CGFloat
+            let intensity: Double
+        }
 
         func attach(to window: NSWindow?) {
             guard let window, self.window == nil else { return }
@@ -255,6 +281,41 @@ struct MainWindowConfigurator: NSViewRepresentable {
                 window.delegate = self
             }
             AppDelegate.shared?.mainWindow = window
+        }
+
+        func requestAmbientBackgroundConfiguration(
+            from host: NSView,
+            showsAmbientBackground: Bool,
+            showsTitlebarAmbientBackground: Bool,
+            colors: ArtworkColors,
+            mainColumnWidth: CGFloat,
+            intensity: Double
+        ) {
+            configurationHost = host
+            pendingAmbientConfiguration = AmbientConfiguration(
+                showsAmbientBackground: showsAmbientBackground,
+                showsTitlebarAmbientBackground: showsTitlebarAmbientBackground,
+                colors: colors,
+                mainColumnWidth: mainColumnWidth,
+                intensity: intensity
+            )
+            guard !hasScheduledAmbientConfiguration else { return }
+            hasScheduledAmbientConfiguration = true
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.hasScheduledAmbientConfiguration = false
+                guard let configuration = self.pendingAmbientConfiguration else { return }
+                self.pendingAmbientConfiguration = nil
+                self.attach(to: self.configurationHost?.window)
+                self.configureAmbientBackground(
+                    configuration.showsAmbientBackground,
+                    showsTitlebarAmbientBackground: configuration.showsTitlebarAmbientBackground,
+                    colors: configuration.colors,
+                    mainColumnWidth: configuration.mainColumnWidth,
+                    intensity: configuration.intensity
+                )
+            }
         }
 
         func configureAmbientBackground(
@@ -344,8 +405,12 @@ struct MainWindowConfigurator: NSViewRepresentable {
                 height: titlebarHeight
             )
 
-            mask.frame = frame
-            mask.isHidden = false
+            if mask.frame != frame {
+                mask.frame = frame
+            }
+            if mask.isHidden {
+                mask.isHidden = false
+            }
             mask.update(
                 colors: colors,
                 appearance: window.effectiveAppearance,
@@ -378,6 +443,9 @@ struct MainWindowConfigurator: NSViewRepresentable {
 
 private final class TitlebarMaskView: NSView {
     private let gradientLayer = CAGradientLayer()
+    private var appliedColors: ArtworkColors?
+    private var appliedAppearanceName: NSAppearance.Name?
+    private var appliedIntensity: Double?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -396,6 +464,15 @@ private final class TitlebarMaskView: NSView {
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
     func update(colors: ArtworkColors, appearance: NSAppearance, intensity: Double) {
+        guard appliedColors != colors
+                || appliedAppearanceName != appearance.name
+                || appliedIntensity != intensity else {
+            return
+        }
+        appliedColors = colors
+        appliedAppearanceName = appearance.name
+        appliedIntensity = intensity
+
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         let opacity = CGFloat(
             MainWindowAmbientOpacity.gradient(isDark: isDark, intensity: intensity)

--- a/Sources/Kumone/Features/Pages/SettingsView.swift
+++ b/Sources/Kumone/Features/Pages/SettingsView.swift
@@ -44,6 +44,29 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 #if os(macOS)
+                Toggle("主界面环境色", isOn: $settings.showMainWindowAmbientBackground)
+                if settings.showMainWindowAmbientBackground {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("背景色强度")
+                            Spacer()
+                            Text("\(Int(settings.mainWindowAmbientBackgroundIntensity * 100))%")
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(
+                            value: $settings.mainWindowAmbientBackgroundIntensity,
+                            in: SettingsManager.mainWindowAmbientBackgroundIntensityRange,
+                            step: 0.1
+                        )
+                        HStack {
+                            Text("50%")
+                            Spacer()
+                            Text("150%")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
                 Toggle("桌面歌词", isOn: $settings.showDesktopLyrics)
                 if settings.showDesktopLyrics {
                     Toggle("桌面歌词水平居中", isOn: $settings.desktopLyricsCentered)

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -7,13 +7,18 @@ struct NowPlayingView: View {
     @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
+    #if os(macOS)
+    @EnvironmentObject private var artworkStore: NowPlayingArtworkStore
+    #endif
     #if os(iOS)
     @Environment(\.dismissNowPlayingAction) private var dismissNowPlayingAction
     @Environment(\.dismissNowPlayingDragAction) private var dismissNowPlayingDragAction
     #endif
 
-    @State private var artworkImage: PlatformImage?
-    @State private var colors: ArtworkColors = .fallback
+    #if os(iOS)
+    @State private var loadedArtworkImage: PlatformImage?
+    @State private var loadedArtworkColors: ArtworkColors = .fallback
+    #endif
     @State private var activeIndex: Int?
     @State private var isUserScrolling = false
     @State private var resumeTask: Task<Void, Never>?
@@ -89,9 +94,11 @@ struct NowPlayingView: View {
         .ignoresSafeArea()
         #endif
         .preferredColorScheme(.dark)
+        #if os(iOS)
         .task(id: player.currentTrack?.id) {
             await loadArtwork()
         }
+        #endif
         #if os(iOS)
         .onAppear {
             showLyricsOnMobile = settings.nowPlayingMode == .immersive
@@ -157,6 +164,22 @@ struct NowPlayingView: View {
 
     // MARK: - Backdrop
 
+    private var artworkImage: PlatformImage? {
+        #if os(macOS)
+        artworkStore.artwork
+        #else
+        loadedArtworkImage
+        #endif
+    }
+
+    private var colors: ArtworkColors {
+        #if os(macOS)
+        artworkStore.colors
+        #else
+        loadedArtworkColors
+        #endif
+    }
+
     private var backdrop: some View {
         ZStack {
             LinearGradient(
@@ -176,18 +199,20 @@ struct NowPlayingView: View {
         .animation(.easeInOut(duration: 0.8), value: colors)
     }
 
+    #if os(iOS)
     private func loadArtwork() async {
         guard let urlString = player.currentTrack?.album.picUrl,
               let url = urlString.resizedImageURL(768) else {
-            artworkImage = nil
-            colors = .fallback
+            loadedArtworkImage = nil
+            loadedArtworkColors = .fallback
             return
         }
         if let image = await ImageCache.shared.image(for: url) {
-            artworkImage = image
-            colors = ArtworkPalette.extract(from: image, cacheKey: urlString)
+            loadedArtworkImage = image
+            loadedArtworkColors = ArtworkPalette.extract(from: image, cacheKey: urlString)
         }
     }
+    #endif
 
     // MARK: - Layouts
 

--- a/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
+++ b/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+#if os(macOS)
+/// A non-interactive artwork tint layered above the split view's opaque system
+/// surfaces. The low opacity keeps system materials and controls readable.
+struct MainWindowAmbientBackground: View {
+    let colors: ArtworkColors
+    let intensity: Double
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var gradientOpacity: Double {
+        MainWindowAmbientOpacity.gradient(
+            isDark: colorScheme == .dark,
+            intensity: intensity
+        )
+    }
+
+    private var glowOpacity: Double {
+        MainWindowAmbientOpacity.glow(
+            isDark: colorScheme == .dark,
+            intensity: intensity
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [colors.primary, colors.secondary],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .opacity(gradientOpacity)
+
+            RadialGradient(
+                colors: [colors.primary.opacity(glowOpacity), .clear],
+                center: .topTrailing,
+                startRadius: 0,
+                endRadius: 680
+            )
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .animation(
+            Platform.isReduceMotionEnabled ? nil : .easeInOut(duration: 0.6),
+            value: colors
+        )
+    }
+}
+
+enum MainWindowAmbientOpacity {
+    static func gradient(isDark: Bool, intensity: Double) -> Double {
+        (isDark ? 0.14 : 0.08) * intensity
+    }
+
+    static func glow(isDark: Bool, intensity: Double) -> Double {
+        (isDark ? 0.18 : 0.12) * intensity
+    }
+}
+#endif

--- a/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
+++ b/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 #if os(macOS)
+import AppKit
+
 /// A non-interactive artwork tint layered above the split view's opaque system
 /// surfaces. The low opacity keeps system materials and controls readable.
 struct MainWindowAmbientBackground: View {
@@ -59,6 +61,178 @@ enum MainWindowAmbientOpacity {
 
     static func glow(isDark: Bool, intensity: Double) -> Double {
         (isDark ? 0.18 : 0.12) * intensity
+    }
+}
+
+struct MainWindowAmbientConfiguration {
+    let showsAmbientBackground: Bool
+    let showsTitlebarAmbientBackground: Bool
+    let colors: ArtworkColors
+    let mainColumnWidth: CGFloat
+    let intensity: Double
+}
+
+/// Owns the AppKit state required to extend the artwork tint through the main
+/// window titlebar while preserving the window's original appearance.
+@MainActor
+final class MainWindowAmbientAppearanceController {
+    private var configuration = MainWindowAmbientConfiguration(
+        showsAmbientBackground: false,
+        showsTitlebarAmbientBackground: false,
+        colors: .fallback,
+        mainColumnWidth: 0,
+        intensity: 1
+    )
+    private var titlebarWasTransparent: Bool?
+    private var hadFullSizeContentView = false
+    private var titlebarMask: TitlebarMaskView?
+
+    func configure(_ configuration: MainWindowAmbientConfiguration, in window: NSWindow) {
+        let wasShowingAmbientBackground = self.configuration.showsAmbientBackground
+        self.configuration = configuration
+
+        guard wasShowingAmbientBackground != configuration.showsAmbientBackground else {
+            updateLayout(in: window)
+            return
+        }
+
+        if configuration.showsAmbientBackground {
+            titlebarWasTransparent = window.titlebarAppearsTransparent
+            hadFullSizeContentView = window.styleMask.contains(.fullSizeContentView)
+            updateLayout(in: window)
+        } else {
+            window.titlebarAppearsTransparent = titlebarWasTransparent ?? false
+            if hadFullSizeContentView {
+                window.styleMask.insert(.fullSizeContentView)
+            } else {
+                window.styleMask.remove(.fullSizeContentView)
+            }
+            titlebarWasTransparent = nil
+            titlebarMask?.removeFromSuperview()
+            titlebarMask = nil
+        }
+    }
+
+    func updateLayout(in window: NSWindow) {
+        guard configuration.showsAmbientBackground else { return }
+        if !window.titlebarAppearsTransparent {
+            window.titlebarAppearsTransparent = true
+        }
+        if !window.styleMask.contains(.fullSizeContentView) {
+            window.styleMask.insert(.fullSizeContentView)
+        }
+        guard configuration.showsTitlebarAmbientBackground else {
+            titlebarMask?.removeFromSuperview()
+            titlebarMask = nil
+            return
+        }
+        installTitlebarMask(in: window)
+        layoutTitlebarMask(in: window)
+    }
+
+    private func installTitlebarMask(in window: NSWindow) {
+        guard titlebarMask == nil, let contentView = window.contentView else { return }
+        let mask = TitlebarMaskView()
+        contentView.addSubview(mask, positioned: .above, relativeTo: nil)
+        titlebarMask = mask
+    }
+
+    private func layoutTitlebarMask(in window: NSWindow) {
+        guard let mask = titlebarMask, let contentView = window.contentView else { return }
+        let width = min(max(configuration.mainColumnWidth, 0), contentView.bounds.width)
+        guard width > 0 else {
+            mask.isHidden = true
+            return
+        }
+
+        let titlebarHeight = contentView.bounds.height - window.contentLayoutRect.height
+        guard titlebarHeight > 0 else {
+            mask.isHidden = true
+            return
+        }
+        let y = contentView.isFlipped
+            ? contentView.bounds.minY
+            : contentView.bounds.maxY - titlebarHeight
+        let frame = CGRect(
+            x: contentView.bounds.maxX - width,
+            y: y,
+            width: width,
+            height: titlebarHeight
+        )
+
+        if mask.frame != frame {
+            mask.frame = frame
+        }
+        if mask.isHidden {
+            mask.isHidden = false
+        }
+        mask.update(
+            colors: configuration.colors,
+            appearance: window.effectiveAppearance,
+            intensity: configuration.intensity
+        )
+    }
+}
+
+private final class TitlebarMaskView: NSView {
+    private let gradientLayer = CAGradientLayer()
+    private var appliedColors: ArtworkColors?
+    private var appliedAppearanceName: NSAppearance.Name?
+    private var appliedIntensity: Double?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.addSublayer(gradientLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    override func layout() {
+        super.layout()
+        gradientLayer.frame = bounds
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    func update(colors: ArtworkColors, appearance: NSAppearance, intensity: Double) {
+        guard appliedColors != colors
+                || appliedAppearanceName != appearance.name
+                || appliedIntensity != intensity else {
+            return
+        }
+        appliedColors = colors
+        appliedAppearanceName = appearance.name
+        appliedIntensity = intensity
+
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let opacity = CGFloat(
+            MainWindowAmbientOpacity.gradient(isDark: isDark, intensity: intensity)
+        )
+        let base = NSColor.windowBackgroundColor
+        let primary = blended(NSColor(colors.primary), over: base, opacity: opacity)
+        let secondary = blended(NSColor(colors.secondary), over: base, opacity: opacity)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(Platform.isReduceMotionEnabled)
+        CATransaction.setAnimationDuration(0.6)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+        gradientLayer.colors = [primary.cgColor, secondary.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 1)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0)
+        CATransaction.commit()
+    }
+
+    private func blended(_ color: NSColor, over base: NSColor, opacity: CGFloat) -> NSColor {
+        let foreground = color.usingColorSpace(.extendedSRGB) ?? color
+        let background = base.usingColorSpace(.extendedSRGB) ?? base
+        return NSColor(
+            red: background.redComponent + (foreground.redComponent - background.redComponent) * opacity,
+            green: background.greenComponent + (foreground.greenComponent - background.greenComponent) * opacity,
+            blue: background.blueComponent + (foreground.blueComponent - background.blueComponent) * opacity,
+            alpha: 1
+        )
     }
 }
 #endif

--- a/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
+++ b/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
@@ -45,6 +45,10 @@ struct MainWindowAmbientBackground: View {
             Platform.isReduceMotionEnabled ? nil : .easeInOut(duration: 0.6),
             value: colors
         )
+        .animation(
+            Platform.isReduceMotionEnabled ? nil : .easeInOut(duration: 0.6),
+            value: intensity
+        )
     }
 }
 

--- a/Sources/Kumone/Features/Shared/NowPlayingArtworkStore.swift
+++ b/Sources/Kumone/Features/Shared/NowPlayingArtworkStore.swift
@@ -21,6 +21,7 @@ final class NowPlayingArtworkStore: ObservableObject {
     private var loadTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
     private var artworkURL: String?
+    private var artworkIsNeeded = false
 
     init(
         player: PlayerService?,
@@ -45,13 +46,30 @@ final class NowPlayingArtworkStore: ObservableObject {
     func update(trackID: Int?, artworkURL: String?) {
         guard self.trackID != trackID || self.artworkURL != artworkURL else { return }
 
-        loadTask?.cancel()
-        loadTask = nil
-        request = nil
+        cancelArtworkLoad()
         self.trackID = trackID
         self.artworkURL = artworkURL
         artwork = nil
         colors = .fallback
+
+        loadArtworkForCurrentTrack()
+    }
+
+    func setArtworkNeeded(_ artworkIsNeeded: Bool) {
+        guard self.artworkIsNeeded != artworkIsNeeded else { return }
+        self.artworkIsNeeded = artworkIsNeeded
+
+        if artworkIsNeeded {
+            loadArtworkForCurrentTrack()
+        } else {
+            cancelArtworkLoad()
+            artwork = nil
+            colors = .fallback
+        }
+    }
+
+    private func loadArtworkForCurrentTrack() {
+        guard artworkIsNeeded else { return }
 
         guard let trackID,
               let artworkURL,
@@ -79,5 +97,11 @@ final class NowPlayingArtworkStore: ObservableObject {
             self.artwork = image
             self.colors = ArtworkPalette.extract(from: image, cacheKey: request.artworkURL)
         }
+    }
+
+    private func cancelArtworkLoad() {
+        loadTask?.cancel()
+        loadTask = nil
+        request = nil
     }
 }

--- a/Sources/Kumone/Features/Shared/NowPlayingArtworkStore.swift
+++ b/Sources/Kumone/Features/Shared/NowPlayingArtworkStore.swift
@@ -1,0 +1,83 @@
+import Combine
+import SwiftUI
+
+/// Shares the current track artwork and palette between macOS surfaces.
+@MainActor
+final class NowPlayingArtworkStore: ObservableObject {
+    typealias ImageLoader = (URL) async -> PlatformImage?
+
+    @Published private(set) var colors: ArtworkColors = .fallback
+    @Published private(set) var artwork: PlatformImage?
+    @Published private(set) var trackID: Int?
+
+    private struct Request: Equatable {
+        let trackID: Int
+        let artworkURL: String
+        let imageURL: URL
+    }
+
+    private let imageLoader: ImageLoader
+    private var request: Request?
+    private var loadTask: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
+    private var artworkURL: String?
+
+    init(
+        player: PlayerService?,
+        imageLoader: @escaping ImageLoader = { url in
+            await ImageCache.shared.image(for: url)
+        }
+    ) {
+        self.imageLoader = imageLoader
+
+        guard let player else { return }
+        player.$currentTrack
+            .sink { [weak self] track in
+                self?.update(trackID: track?.id, artworkURL: track?.album.picUrl)
+            }
+            .store(in: &cancellables)
+    }
+
+    convenience init() {
+        self.init(player: PlayerService.shared)
+    }
+
+    func update(trackID: Int?, artworkURL: String?) {
+        guard self.trackID != trackID || self.artworkURL != artworkURL else { return }
+
+        loadTask?.cancel()
+        loadTask = nil
+        request = nil
+        self.trackID = trackID
+        self.artworkURL = artworkURL
+        artwork = nil
+        colors = .fallback
+
+        guard let trackID,
+              let artworkURL,
+              let imageURL = artworkURL.resizedImageURL(768) else {
+            return
+        }
+
+        let request = Request(
+            trackID: trackID,
+            artworkURL: artworkURL,
+            imageURL: imageURL
+        )
+        self.request = request
+        let imageLoader = imageLoader
+        loadTask = Task { [weak self] in
+            let image = await imageLoader(request.imageURL)
+            guard !Task.isCancelled,
+                  let self,
+                  self.request == request else {
+                return
+            }
+
+            self.loadTask = nil
+            guard let image else { return }
+            self.artwork = image
+            self.colors = ArtworkPalette.extract(from: image, cacheKey: request.artworkURL)
+        }
+    }
+}

--- a/Tests/KumoneCoreTests/NowPlayingArtworkStoreTests.swift
+++ b/Tests/KumoneCoreTests/NowPlayingArtworkStoreTests.swift
@@ -15,6 +15,7 @@ struct NowPlayingArtworkStoreTests {
             }
             return secondArtwork
         }
+        store.setArtworkNeeded(true)
 
         store.update(
             trackID: 1,
@@ -41,18 +42,42 @@ struct NowPlayingArtworkStoreTests {
     }
 
     @Test func failedArtworkLoadUsesFallback() async {
-        let store = NowPlayingArtworkStore(player: nil) { _ in nil }
+        let loaderCalls = ImageLoaderCallSignal()
+        let store = NowPlayingArtworkStore(player: nil) { _ in
+            await loaderCalls.record()
+            return nil
+        }
+        store.setArtworkNeeded(true)
 
         store.update(
             trackID: 1,
             artworkURL: "https://example.com/missing-artwork.jpg"
         )
-        await Task.yield()
-        await Task.yield()
+        await loaderCalls.waitForCall()
 
         #expect(store.trackID == 1)
         #expect(store.artwork == nil)
         #expect(store.colors == .fallback)
+    }
+
+    @Test func waitsForAConsumerBeforeLoadingArtwork() async {
+        let loaderCalls = ImageLoaderCallSignal()
+        let store = NowPlayingArtworkStore(player: nil) { _ in
+            await loaderCalls.record()
+            return nil
+        }
+
+        store.update(
+            trackID: 1,
+            artworkURL: "https://example.com/artwork.jpg"
+        )
+
+        #expect(await loaderCalls.callCount() == 0)
+
+        store.setArtworkNeeded(true)
+        await loaderCalls.waitForCall()
+
+        #expect(await loaderCalls.callCount() == 1)
     }
 
     private func artwork(color: NSColor) -> PlatformImage {
@@ -63,4 +88,23 @@ struct NowPlayingArtworkStoreTests {
         image.unlockFocus()
         return image
     }
+}
+
+private actor ImageLoaderCallSignal {
+    private var count = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func record() {
+        count += 1
+        let waiters = waiters
+        self.waiters = []
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitForCall() async {
+        guard count == 0 else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func callCount() -> Int { count }
 }

--- a/Tests/KumoneCoreTests/NowPlayingArtworkStoreTests.swift
+++ b/Tests/KumoneCoreTests/NowPlayingArtworkStoreTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Testing
+@testable import KumoneCore
+
+@Suite("Now Playing Artwork Store Tests")
+@MainActor
+struct NowPlayingArtworkStoreTests {
+    @Test func latestArtworkRequestWins() async {
+        let firstArtwork = artwork(color: .systemRed)
+        let secondArtwork = artwork(color: .systemBlue)
+        let store = NowPlayingArtworkStore(player: nil) { url in
+            if url.absoluteString.contains("first-artwork") {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                return firstArtwork
+            }
+            return secondArtwork
+        }
+
+        store.update(
+            trackID: 1,
+            artworkURL: "https://example.com/first-artwork.jpg"
+        )
+        store.update(
+            trackID: 2,
+            artworkURL: "https://example.com/second-artwork.jpg"
+        )
+        try? await Task.sleep(nanoseconds: 40_000_000)
+
+        #expect(store.trackID == 2)
+        #expect(store.artwork === secondArtwork)
+    }
+
+    @Test func missingArtworkImmediatelyUsesFallback() {
+        let store = NowPlayingArtworkStore(player: nil) { _ in artwork(color: .systemRed) }
+
+        store.update(trackID: 1, artworkURL: nil)
+
+        #expect(store.trackID == 1)
+        #expect(store.artwork == nil)
+        #expect(store.colors == .fallback)
+    }
+
+    @Test func failedArtworkLoadUsesFallback() async {
+        let store = NowPlayingArtworkStore(player: nil) { _ in nil }
+
+        store.update(
+            trackID: 1,
+            artworkURL: "https://example.com/missing-artwork.jpg"
+        )
+        await Task.yield()
+        await Task.yield()
+
+        #expect(store.trackID == 1)
+        #expect(store.artwork == nil)
+        #expect(store.colors == .fallback)
+    }
+
+    private func artwork(color: NSColor) -> PlatformImage {
+        let image = PlatformImage(size: NSSize(width: 2, height: 2))
+        image.lockFocus()
+        color.setFill()
+        NSRect(x: 0, y: 0, width: 2, height: 2).fill()
+        image.unlockFocus()
+        return image
+    }
+}


### PR DESCRIPTION
# feat(macos): add main window artwork ambient background

## 概述

此 PR 为 macOS 主窗口加入可选的封面环境色背景。背景色从当前播放歌曲的封面中提取，使主窗口与播放详情页使用同一组视觉色彩。

该设置默认开启，可在“设置 → 外观 → 背景色强度”中调整。强度会持久化保存，并限制在 50%–150% 范围内。

## 变更内容

### 主窗口环境色

- 新增 `MainWindowAmbientBackground`，使用封面调色板中的主色和次色渲染不响应点击的 SwiftUI 渐变层。
- 通过 AppKit 渐变遮罩将环境色延伸到右侧标题栏，使内容区与标题栏保持连续。
- 根据浅色和深色外观使用低透明度叠加层，保证边栏和系统控件可读。
- 遵从“减少动态效果”系统设置：启用时不播放封面颜色和强度切换动画。

### 播放详情页

- macOS 播放详情页复用同一份封面和调色板，不再重复加载封面。
- 展开完整播放详情页时隐藏标题栏遮罩，避免沉浸式封面背景顶部出现一条标题栏色带。

### 封面加载与生命周期

- 新增 `NowPlayingArtworkStore`，统一持有当前 768 px 封面及其提取的调色板。
- 仅当主界面环境色开启或播放详情页打开时加载封面。
- 没有 macOS 界面需要封面时，取消在途请求并释放封面和调色板。
- 校验异步请求对应的歌曲，避免上一首歌曲的迟到结果覆盖当前界面。

### 窗口职责

- `MainWindowConfigurator` 仅负责窗口挂载、关闭拦截和配置合并。
- `MainWindowAmbientAppearanceController` 负责标题栏外观、遮罩布局和原生渐变更新。

## 效果

 <img width="1164" height="780" alt="pr-86-ambient-main-window" src="https://github.com/user-attachments/assets/806333c5-4d57-4835-8b1c-ba4360ae3c18" />
 <img width="1167" height="779" alt="pr-86-ambient-now-playing" src="https://github.com/user-attachments/assets/2e71c011-b8ef-4fd6-be1d-3a26561eb264" /> 
 <img width="432" height="350" alt="pr-86-ambient-settings" src="https://github.com/user-attachments/assets/1e5bac72-a376-4fdc-88c7-bea9d1c67c36" /> 

## 验证

- `swift test`
- `Scripts/compile_and_run.sh`
- 使用正在播放的歌曲在 macOS 手动检查：
  - 主窗口内容区和标题栏均渲染封面环境色；
  - 打开播放详情页后标题栏遮罩消失，封面背景保持连续；
  - 外观页滑块可在 50%–150% 范围内调整并保存背景色强度。

## 范围

- 仅涉及 macOS 界面行为。
- iOS 继续使用现有的播放详情页封面加载路径。
