### PR TITLE
fix(macos): avoid duplicate search fields

### DIFF
--- a/Sources/Kumone/Features/Pages/SearchView.swift
+++ b/Sources/Kumone/Features/Pages/SearchView.swift
@@ -66,14 +66,11 @@ final class SearchViewModel: ObservableObject {
 }
 
 struct SearchView: View {
-    let initialQuery: String
-
     @StateObject private var model: SearchViewModel
     @State private var searchText: String = ""
     @EnvironmentObject private var player: PlayerService
 
     init(query: String) {
-        self.initialQuery = query
         _model = StateObject(wrappedValue: SearchViewModel(query: query))
         _searchText = State(initialValue: query)
     }
@@ -104,6 +101,10 @@ struct SearchView: View {
                 PlayerClearanceSpacer()
             }
         }
+        #if os(iOS)
+        // iPad enters SearchView from the sidebar, where the desktop window
+        // toolbar search field is unavailable. On macOS, MainWindow owns the
+        // only search field and navigates here with its submitted query.
         .searchable(text: $searchText, prompt: "搜索歌曲、歌手、专辑、歌单")
         .onSubmit(of: .search) {
             model.setQuery(searchText)
@@ -118,6 +119,7 @@ struct SearchView: View {
                 }
             }
         }
+        #endif
         .navigationTitle(searchText.isEmpty ? "搜索" : String(localized: "搜索：\(searchText)"))
         .task(id: model.tab) {
             await model.load(tab: model.tab)


### PR DESCRIPTION
# fix(macos): avoid duplicate search fields

## 概述

修复 macOS 中从主窗口工具栏提交搜索后，搜索结果页标题栏再次出现系统搜索框的问题。

Closes #89

## 变更内容

### macOS 搜索入口

`MainWindow` 的 `SearchFieldView` 继续作为 macOS 的搜索输入入口。提交关键词后，应用进入 `SearchView` 并加载对应结果；结果页不再创建第二个系统搜索框。

### iPad 搜索入口

将 `SearchView` 的 `.searchable`、提交处理和输入变化处理限定在 iOS 构建中。iPad 仍可从侧边栏进入搜索页并使用页面顶部的系统搜索框。

### 清理无用状态

移除 `SearchView` 中未参与界面或查询逻辑的 `initialQuery` 存储属性。

## 验证

- `swift test`（2 个测试通过）
- `Scripts/compile_and_run.sh` 成功构建并启动 macOS 应用
- 在 macOS 主窗口搜索 `Love`：标题栏仅保留工具栏搜索框，搜索结果正常加载
- 在 iPad 入口复核 `SearchView` 仍保留系统搜索框和原有提交逻辑

## 范围

此次改动集中在 `SearchView` 的平台条件编译。