### PR TITLE
fix(macos): keep now-playing artwork aligned during presentation

### DIFF
--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -127,6 +127,9 @@ struct MainWindow: View {
                 #if os(macOS)
                 NowPlayingView()
                     .environmentObject(artworkStore)
+                    // Resolve the slide at the page boundary, including artwork
+                    // inserted asynchronously while the transition is running.
+                    .geometryGroup()
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 #else
                 NowPlayingView()


### PR DESCRIPTION
## Problem

On macOS, opening the now-playing page could make the album artwork appear immediately at its final position while the rest of the page slid up from the bottom. Dismissing the page moved everything down together. The reporter observed this on version 0.3.17.

The page uses a move-and-opacity transition, but its artwork can be inserted asynchronously during that transition. SwiftUI normally propagates geometry changes down to individual leaf views, so newly inserted artwork can miss the in-progress movement and appear at its destination.

## Fix

Add `geometryGroup()` to the macOS `NowPlayingView` before its transition. This resolves the animated geometry at the page boundary, keeping artwork inserted during presentation aligned with the rest of the page. The change is limited to the macOS presentation path.

## Validation

- `swift test`: all 10 tests passed.
- `Scripts/build-app.sh debug`: build and packaging succeeded.
- The reporter tested the patched preview build and confirmed that the issue is resolved.

The existing tests cover core behavior; the animation fix was verified manually by the reporter.
