### PR TITLE
fix(macos): 修复外观切换后的界面颜色不一致

### DIFF
--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -4,6 +4,7 @@ struct MainWindow: View {
 #if os(macOS)
     @Environment(\.openWindow) private var openWindow
 #endif
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var player: PlayerService
     @EnvironmentObject private var account: AccountStore
     @EnvironmentObject private var settings: SettingsManager
@@ -75,7 +76,8 @@ struct MainWindow: View {
                     showsTitlebarAmbientBackground: !player.showNowPlaying,
                     colors: artworkStore.colors,
                     mainColumnWidth: detailWidth,
-                    intensity: settings.mainWindowAmbientBackgroundIntensity
+                    intensity: settings.mainWindowAmbientBackgroundIntensity,
+                    isDark: isDarkAppearance
                 )
             )
         )
@@ -211,6 +213,10 @@ struct MainWindow: View {
     #if os(macOS)
     private var needsCurrentArtwork: Bool {
         settings.showMainWindowAmbientBackground || player.showNowPlaying
+    }
+
+    private var isDarkAppearance: Bool {
+        (settings.appearance.colorScheme ?? colorScheme) == .dark
     }
     #endif
 }

--- a/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
+++ b/Sources/Kumone/Features/Shared/MainWindowAmbientBackground.swift
@@ -70,6 +70,7 @@ struct MainWindowAmbientConfiguration {
     let colors: ArtworkColors
     let mainColumnWidth: CGFloat
     let intensity: Double
+    let isDark: Bool
 }
 
 /// Owns the AppKit state required to extend the artwork tint through the main
@@ -81,7 +82,8 @@ final class MainWindowAmbientAppearanceController {
         showsTitlebarAmbientBackground: false,
         colors: .fallback,
         mainColumnWidth: 0,
-        intensity: 1
+        intensity: 1,
+        isDark: false
     )
     private var titlebarWasTransparent: Bool?
     private var hadFullSizeContentView = false
@@ -168,8 +170,8 @@ final class MainWindowAmbientAppearanceController {
         }
         mask.update(
             colors: configuration.colors,
-            appearance: window.effectiveAppearance,
-            intensity: configuration.intensity
+            intensity: configuration.intensity,
+            isDark: configuration.isDark
         )
     }
 }
@@ -177,8 +179,8 @@ final class MainWindowAmbientAppearanceController {
 private final class TitlebarMaskView: NSView {
     private let gradientLayer = CAGradientLayer()
     private var appliedColors: ArtworkColors?
-    private var appliedAppearanceName: NSAppearance.Name?
     private var appliedIntensity: Double?
+    private var appliedIsDark: Bool?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -196,21 +198,26 @@ private final class TitlebarMaskView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
-    func update(colors: ArtworkColors, appearance: NSAppearance, intensity: Double) {
+    func update(colors: ArtworkColors, intensity: Double, isDark: Bool) {
         guard appliedColors != colors
-                || appliedAppearanceName != appearance.name
-                || appliedIntensity != intensity else {
+                || appliedIntensity != intensity
+                || appliedIsDark != isDark else {
             return
         }
         appliedColors = colors
-        appliedAppearanceName = appearance.name
         appliedIntensity = intensity
+        appliedIsDark = isDark
 
-        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         let opacity = CGFloat(
             MainWindowAmbientOpacity.gradient(isDark: isDark, intensity: intensity)
         )
-        let base = NSColor.windowBackgroundColor
+        let appearanceName: NSAppearance.Name = isDark ? .darkAqua : .aqua
+        var base = NSColor.windowBackgroundColor.usingColorSpace(.extendedSRGB)
+            ?? NSColor.windowBackgroundColor
+        NSAppearance(named: appearanceName)?.performAsCurrentDrawingAppearance {
+            base = NSColor.windowBackgroundColor.usingColorSpace(.extendedSRGB)
+                ?? NSColor.windowBackgroundColor
+        }
         let primary = blended(NSColor(colors.primary), over: base, opacity: opacity)
         let secondary = blended(NSColor(colors.secondary), over: base, opacity: opacity)
 


### PR DESCRIPTION
## 背景

PR #86 为 macOS 主窗口加入了基于封面颜色的环境色背景和标题栏渐变。

主窗口顶部遮罩使用 AppKit 图层绘制。用户在 macOS“系统设置”中手动切换浅色和深色外观时，SwiftUI 内容会更新，但顶部遮罩可能保留切换前的浅色或深色底色。

## 复现步骤

1. 在 Kumone 设置中将“主题”设为“跟随系统”。
2. 保持 Kumone 主窗口打开。
3. 在 macOS“系统设置 → 外观”中切换浅色和深色模式。

## 修复前表现

预期：主窗口顶部遮罩与页面内容同时切换，环境色在新的系统底色上重新混合。

实际：页面内容已切换，顶部遮罩仍保留切换前的外观。


https://github.com/user-attachments/assets/9f62c503-eb50-458f-8b91-29f275d1f892



## 修复内容

### 标题栏环境色订阅 SwiftUI 的环境外观

`MainWindow` 读取 SwiftUI 的 `colorScheme`。当用户在 macOS“系统设置”中改变外观、且 Kumone 使用“跟随系统”时，SwiftUI 会重新计算窗口配置，并把新的深浅色值传给标题栏环境色配置。

标题栏仍以解析后的 `.aqua` 或 `.darkAqua` 取得系统窗口底色，再与封面主色、辅色混合；显式选择浅色或深色时，设置值优先于系统环境。

## 性能与兼容性

- 标题栏渐变缓存上一次的封面颜色、强度和深浅色；这些值未变化时不会重新设置 Core Animation 图层。
- 系统外观变化时仅重新计算主窗口配置，不参与播放进度、列表滚动等高频路径。
- 标题栏实现均处于 `#if os(macOS)`，不会改变 iOS/iPadOS 的编译产物和行为。
- 主窗口已有的标题栏透明度和 `fullSizeContentView` 恢复逻辑保持不变。

## 验证

- [x] `git diff --check`
- [x] `Scripts/compile_and_run.sh`
- [x] 在 macOS“系统设置”中实际往返切换浅色和深色，顶部遮罩与主内容同步更新。

https://github.com/user-attachments/assets/32ed8df6-9e81-4cb5-a956-77307d66f0a9



编译过程中仅出现项目现有的 `onChange(of:perform:)` 弃用告警，以及系统媒体框架的 dyld 符号告警
## 关联

- 关联已合并的 PR #86：主窗口环境色背景
- #94 在 PR #86 合并前已存在，该问题单独跟踪不由本 PR 关闭
