### PR TITLE
feat(navigation): open artists and albums from tracks

### DIFF
--- a/Sources/Kumone/Features/IOSMainWindow.swift
+++ b/Sources/Kumone/Features/IOSMainWindow.swift
@@ -35,6 +35,7 @@ public struct IOSMainWindow: View {
             .tint(Theme.accent)
             .preferredColorScheme(settings.appearance.colorScheme)
             .environment(\.openLogin, { showLogin = true })
+            .environment(\.openDestination, openDestination)
             .task {
                 await account.bootstrap()
                 if settings.autoCheckUpdates {
@@ -151,7 +152,7 @@ public struct IOSMainWindow: View {
             usesSystemInteractiveDismissal: usesSystemInteractiveDismissal,
             dismissAnimation: dismissAnimation
         ) {
-            NowPlayingView()
+            NowPlayingView(onOpenDestination: openDestination)
                 .environmentObject(player)
                 .environmentObject(account)
                 .environmentObject(settings)
@@ -251,6 +252,11 @@ public struct IOSMainWindow: View {
         case .search: searchPath = NavigationPath()
         case .library: libraryPath = NavigationPath()
         }
+    }
+
+    private func openDestination(_ destination: Destination) {
+        player.showNowPlaying = false
+        binding(for: selectedTab).wrappedValue.append(destination)
     }
 
     @ViewBuilder

--- a/Sources/Kumone/Features/IOSMainWindow.swift
+++ b/Sources/Kumone/Features/IOSMainWindow.swift
@@ -18,11 +18,12 @@ public struct IOSMainWindow: View {
 
     @State private var selectedTab: IOSTab = .home
     @State private var showLogin = false
-    @State private var homePath = NavigationPath()
-    @State private var explorePath = NavigationPath()
-    @State private var fmPath = NavigationPath()
-    @State private var searchPath = NavigationPath()
-    @State private var libraryPath = NavigationPath()
+    @State private var homePath: [Destination] = []
+    @State private var explorePath: [Destination] = []
+    @State private var fmPath: [Destination] = []
+    @State private var searchPath: [Destination] = []
+    @State private var libraryPath: [Destination] = []
+    @State private var iPadPath: [Destination] = []
 
     public init() {}
 
@@ -136,7 +137,7 @@ public struct IOSMainWindow: View {
     @ViewBuilder
     private var appContent: some View {
         if UIDevice.current.userInterfaceIdiom == .pad {
-            MainWindow()
+            MainWindow(path: $iPadPath)
         } else {
             tabInterface
         }
@@ -246,17 +247,25 @@ public struct IOSMainWindow: View {
 
     private func popToRoot(_ tab: IOSTab) {
         switch tab {
-        case .home: homePath = NavigationPath()
-        case .explore: explorePath = NavigationPath()
-        case .fm: fmPath = NavigationPath()
-        case .search: searchPath = NavigationPath()
-        case .library: libraryPath = NavigationPath()
+        case .home: homePath = []
+        case .explore: explorePath = []
+        case .fm: fmPath = []
+        case .search: searchPath = []
+        case .library: libraryPath = []
         }
     }
 
     private func openDestination(_ destination: Destination) {
         player.showNowPlaying = false
-        binding(for: selectedTab).wrappedValue.append(destination)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            iPadPath.appendIfNotCurrent(destination)
+            return
+        }
+
+        let path = binding(for: selectedTab)
+        var destinations = path.wrappedValue
+        destinations.appendIfNotCurrent(destination)
+        path.wrappedValue = destinations
     }
 
     @ViewBuilder
@@ -280,7 +289,7 @@ public struct IOSMainWindow: View {
             .zIndex(selectedTab == tab ? 1 : 0)
     }
 
-    private func binding(for tab: IOSTab) -> Binding<NavigationPath> {
+    private func binding(for tab: IOSTab) -> Binding<[Destination]> {
         switch tab {
         case .home: return $homePath
         case .explore: return $explorePath

--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -82,6 +82,7 @@ struct MainWindow: View {
         #endif
         .playerChrome(detailWidth: detailWidth)
         .environment(\.openLogin, { showLogin = true })
+        .environment(\.openDestination, openDestination)
         #if os(macOS)
         .environmentObject(artworkStore)
         #endif
@@ -125,14 +126,14 @@ struct MainWindow: View {
         .overlay {
             if player.showNowPlaying {
                 #if os(macOS)
-                NowPlayingView()
+                NowPlayingView(onOpenDestination: openDestination)
                     .environmentObject(artworkStore)
                     // Resolve the slide at the page boundary, including artwork
                     // inserted asynchronously while the transition is running.
                     .geometryGroup()
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 #else
-                NowPlayingView()
+                NowPlayingView(onOpenDestination: openDestination)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 #endif
             }
@@ -157,6 +158,11 @@ struct MainWindow: View {
         .onChange(of: selection) { _ in
             path = NavigationPath()
         }
+    }
+
+    private func openDestination(_ destination: Destination) {
+        player.showNowPlaying = false
+        path.append(destination)
     }
 
     @ViewBuilder

--- a/Sources/Kumone/Features/MainWindow.swift
+++ b/Sources/Kumone/Features/MainWindow.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct MainWindow: View {
+    private let externalPath: Binding<[Destination]>?
 #if os(macOS)
     @Environment(\.openWindow) private var openWindow
 #endif
@@ -13,11 +14,30 @@ struct MainWindow: View {
     @StateObject private var artworkStore = NowPlayingArtworkStore()
     #endif
     @State private var selection: SidebarItem = .home
-    @State private var path = NavigationPath()
+    @State private var localPath: [Destination] = []
     @State private var showLogin = false
     @State private var detailWidth: CGFloat = 0
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var visibilityBeforeNowPlaying: NavigationSplitViewVisibility?
+
+    init(path: Binding<[Destination]>? = nil) {
+        externalPath = path
+    }
+
+    private var path: [Destination] {
+        get { externalPath?.wrappedValue ?? localPath }
+        nonmutating set {
+            if let externalPath {
+                externalPath.wrappedValue = newValue
+            } else {
+                localPath = newValue
+            }
+        }
+    }
+
+    private var pathBinding: Binding<[Destination]> {
+        externalPath ?? $localPath
+    }
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -150,19 +170,32 @@ struct MainWindow: View {
     }
 
     private var detailStack: some View {
-        NavigationStack(path: $path) {
+        NavigationStack(path: pathBinding) {
             rootView
                 .playerContentInset()
                 .appDestinations()
         }
         .onChange(of: selection) { _ in
-            path = NavigationPath()
+            path = []
         }
     }
 
     private func openDestination(_ destination: Destination) {
+        #if os(macOS)
+        guard player.showNowPlaying else {
+            path.appendIfNotCurrent(destination)
+            return
+        }
+
+        withAnimation(AppAnimation.smooth, completionCriteria: .removed) {
+            player.showNowPlaying = false
+        } completion: {
+            path.appendIfNotCurrent(destination)
+        }
+        #else
         player.showNowPlaying = false
-        path.append(destination)
+        path.appendIfNotCurrent(destination)
+        #endif
     }
 
     @ViewBuilder

--- a/Sources/Kumone/Features/Navigation.swift
+++ b/Sources/Kumone/Features/Navigation.swift
@@ -81,6 +81,13 @@ enum Destination: Hashable {
     case search(String)
 }
 
+extension Array where Element == Destination {
+    mutating func appendIfNotCurrent(_ destination: Destination) {
+        guard last != destination else { return }
+        append(destination)
+    }
+}
+
 /// Registers all shared navigation destinations on a stack.
 struct DestinationsModifier: ViewModifier {
     func body(content: Content) -> some View {

--- a/Sources/Kumone/Features/Navigation.swift
+++ b/Sources/Kumone/Features/Navigation.swift
@@ -4,10 +4,19 @@ private struct OpenLoginKey: EnvironmentKey {
     static let defaultValue: () -> Void = {}
 }
 
+private struct OpenDestinationKey: EnvironmentKey {
+    static let defaultValue: (Destination) -> Void = { _ in }
+}
+
 extension EnvironmentValues {
     var openLogin: () -> Void {
         get { self[OpenLoginKey.self] }
         set { self[OpenLoginKey.self] = newValue }
+    }
+
+    var openDestination: (Destination) -> Void {
+        get { self[OpenDestinationKey.self] }
+        set { self[OpenDestinationKey.self] = newValue }
     }
 }
 

--- a/Sources/Kumone/Features/Player/NowPlayingTrackDestinationLinks.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingTrackDestinationLinks.swift
@@ -6,8 +6,7 @@ struct NowPlayingTrackDestinationLinks: View {
     let track: Track
     let font: Font
     let color: Color
-
-    @Environment(\.openDestination) private var openDestination
+    let onOpenDestination: (Destination) -> Void
 
     private var artists: [ArtistRef] {
         track.artists.filter { $0.id > 0 && !$0.name.isEmpty }
@@ -15,27 +14,35 @@ struct NowPlayingTrackDestinationLinks: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
-                if index > 0 {
-                    Text(" / ")
+            if artists.isEmpty {
+                Text(track.artistNames)
+            } else {
+                ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                    if index > 0 {
+                        Text(" / ")
+                    }
+                    Button {
+                        onOpenDestination(.artist(artist.id))
+                    } label: {
+                        Text(artist.name)
+                            .contentShape(Rectangle())
+                            .padding(.vertical, 3)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("打开歌手：\(artist.name)")
                 }
-                Button {
-                    openDestination(.artist(artist.id))
-                } label: {
-                    Text(artist.name)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("打开歌手：\(artist.name)")
             }
 
             if track.album.id > 0, !track.album.name.isEmpty {
-                if !artists.isEmpty {
+                if !track.artistNames.isEmpty {
                     Text(" — ")
                 }
                 Button {
-                    openDestination(.album(track.album.id))
+                    onOpenDestination(.album(track.album.id))
                 } label: {
                     Text(track.album.name)
+                        .contentShape(Rectangle())
+                        .padding(.vertical, 3)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("打开专辑：\(track.album.name)")
@@ -44,5 +51,6 @@ struct NowPlayingTrackDestinationLinks: View {
         .font(font)
         .foregroundStyle(color)
         .lineLimit(1)
+        .accessibilityElement(children: .contain)
     }
 }

--- a/Sources/Kumone/Features/Player/NowPlayingTrackDestinationLinks.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingTrackDestinationLinks.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Links the current track metadata to its artist and album without requiring
+/// the immersive presentation to own a second navigation stack.
+struct NowPlayingTrackDestinationLinks: View {
+    let track: Track
+    let font: Font
+    let color: Color
+
+    @Environment(\.openDestination) private var openDestination
+
+    private var artists: [ArtistRef] {
+        track.artists.filter { $0.id > 0 && !$0.name.isEmpty }
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                if index > 0 {
+                    Text(" / ")
+                }
+                Button {
+                    openDestination(.artist(artist.id))
+                } label: {
+                    Text(artist.name)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("打开歌手：\(artist.name)")
+            }
+
+            if track.album.id > 0, !track.album.name.isEmpty {
+                if !artists.isEmpty {
+                    Text(" — ")
+                }
+                Button {
+                    openDestination(.album(track.album.id))
+                } label: {
+                    Text(track.album.name)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("打开专辑：\(track.album.name)")
+            }
+        }
+        .font(font)
+        .foregroundStyle(color)
+        .lineLimit(1)
+    }
+}

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Immersive full-window now-playing page: artwork-tinted gradient backdrop,
 /// large artwork on the left, big synced lyrics on the right.
 struct NowPlayingView: View {
-    var onOpenDestination: (Destination) -> Void = { _ in }
+    let onOpenDestination: (Destination) -> Void
 
     @EnvironmentObject private var player: PlayerService
     @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
@@ -96,7 +96,6 @@ struct NowPlayingView: View {
         .ignoresSafeArea()
         #endif
         .preferredColorScheme(.dark)
-        .environment(\.openDestination, onOpenDestination)
         #if os(iOS)
         .task(id: player.currentTrack?.id) {
             await loadArtwork()
@@ -275,7 +274,10 @@ struct NowPlayingView: View {
                 height: NowPlayingPresentationMetrics.immersiveHeaderTopInset
             )
 
-            CompactTrackHeader(showsExpandedArtwork: showsVinyl)
+            CompactTrackHeader(
+                showsExpandedArtwork: showsVinyl,
+                onOpenDestination: onOpenDestination
+            )
                 .padding(.bottom, 10)
             #else
             Spacer().frame(height: 30)
@@ -407,6 +409,7 @@ struct NowPlayingView: View {
 
             CompactTrackHeader(
                 showsExpandedArtwork: showsExpandedArtwork,
+                onOpenDestination: onOpenDestination,
                 onTapArtwork: collapseImmersiveArtwork
             )
             .padding(.bottom, 14)
@@ -557,7 +560,10 @@ struct NowPlayingView: View {
         return VStack(spacing: 0) {
             ZStack(alignment: .top) {
                 Color.clear
-                MinimalTrackInfoRow(metadataOnly: true)
+                MinimalTrackInfoRow(
+                    onOpenDestination: onOpenDestination,
+                    metadataOnly: true
+                )
                     .padding(.top, NowPlayingPresentationMetrics.immersiveHeaderTopInset)
                     .opacity(showLyricsOnMobile ? 1 : 0)
                     .accessibilityHidden(!showLyricsOnMobile)
@@ -604,11 +610,14 @@ struct NowPlayingView: View {
     private var minimalControls: some View {
         VStack(spacing: 22) {
             ZStack {
-                MinimalTrackInfoRow()
+                MinimalTrackInfoRow(onOpenDestination: onOpenDestination)
                     .opacity(showLyricsOnMobile ? 0 : 1)
                     .allowsHitTesting(!showLyricsOnMobile)
                     .accessibilityHidden(showLyricsOnMobile)
-                MinimalTrackInfoRow(actionsOnly: true)
+                MinimalTrackInfoRow(
+                    onOpenDestination: onOpenDestination,
+                    actionsOnly: true
+                )
                     .opacity(showLyricsOnMobile ? 1 : 0)
                     .allowsHitTesting(showLyricsOnMobile)
                     .accessibilityHidden(!showLyricsOnMobile)
@@ -709,7 +718,8 @@ struct NowPlayingView: View {
                 NowPlayingTrackDestinationLinks(
                     track: track,
                     font: .system(size: 13.5),
-                    color: .white.opacity(0.65)
+                    color: .white.opacity(0.65),
+                    onOpenDestination: onOpenDestination
                 )
             }
         }
@@ -1202,6 +1212,7 @@ private struct CompactTrackHeader: View {
     @State private var showAddToPlaylist = false
 
     let showsExpandedArtwork: Bool
+    let onOpenDestination: (Destination) -> Void
     /// Tap handler for the compact cover (used to collapse lyrics back to
     /// artwork). The real image floats above this placeholder with hit-testing
     /// disabled, so taps land here.
@@ -1235,7 +1246,8 @@ private struct CompactTrackHeader: View {
                     NowPlayingTrackDestinationLinks(
                         track: track,
                         font: .subheadline,
-                        color: .white.opacity(0.62)
+                        color: .white.opacity(0.62),
+                        onOpenDestination: onOpenDestination
                     )
                 }
             }
@@ -1930,6 +1942,7 @@ private struct MinimalTrackInfoRow: View {
     @EnvironmentObject private var account: AccountStore
     @State private var showAddToPlaylist = false
     @State private var airPlayRequest = 0
+    let onOpenDestination: (Destination) -> Void
     var metadataOnly = false
     var actionsOnly = false
 
@@ -1983,7 +1996,8 @@ private struct MinimalTrackInfoRow: View {
                 NowPlayingTrackDestinationLinks(
                     track: track,
                     font: .footnote,
-                    color: .white.opacity(0.62)
+                    color: .white.opacity(0.62),
+                    onOpenDestination: onOpenDestination
                 )
             }
         }

--- a/Sources/Kumone/Features/Player/NowPlayingView.swift
+++ b/Sources/Kumone/Features/Player/NowPlayingView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Immersive full-window now-playing page: artwork-tinted gradient backdrop,
 /// large artwork on the left, big synced lyrics on the right.
 struct NowPlayingView: View {
+    var onOpenDestination: (Destination) -> Void = { _ in }
+
     @EnvironmentObject private var player: PlayerService
     @ObservedObject private var lyricsCursor = PlayerService.shared.lyricsCursor
     @EnvironmentObject private var account: AccountStore
@@ -94,6 +96,7 @@ struct NowPlayingView: View {
         .ignoresSafeArea()
         #endif
         .preferredColorScheme(.dark)
+        .environment(\.openDestination, onOpenDestination)
         #if os(iOS)
         .task(id: player.currentTrack?.id) {
             await loadArtwork()
@@ -654,6 +657,22 @@ struct NowPlayingView: View {
 
     private func artworkView(size: CGFloat) -> some View {
         Group {
+            if let album = player.currentTrack?.album, album.id > 0, !album.name.isEmpty {
+                Button {
+                    onOpenDestination(.album(album.id))
+                } label: {
+                    artworkSurface(size: size)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("打开专辑：\(album.name)")
+            } else {
+                artworkSurface(size: size)
+            }
+        }
+    }
+
+    private func artworkSurface(size: CGFloat) -> some View {
+        Group {
             if let artworkImage {
                 Image(platformImage: artworkImage)
                     .resizable()
@@ -686,10 +705,13 @@ struct NowPlayingView: View {
                     VIPBadge()
                 }
             }
-            Text("\(player.currentTrack?.artistNames ?? "") — \(player.currentTrack?.album.name ?? "")")
-                .font(.system(size: 13.5))
-                .foregroundStyle(.white.opacity(0.65))
-                .lineLimit(1)
+            if let track = player.currentTrack {
+                NowPlayingTrackDestinationLinks(
+                    track: track,
+                    font: .system(size: 13.5),
+                    color: .white.opacity(0.65)
+                )
+            }
         }
         .frame(maxWidth: 400)
     }
@@ -1209,10 +1231,13 @@ private struct CompactTrackHeader: View {
                         VIPBadge()
                     }
                 }
-                Text(player.currentTrack?.artistNames ?? "")
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.62))
-                    .lineLimit(1)
+                if let track = player.currentTrack {
+                    NowPlayingTrackDestinationLinks(
+                        track: track,
+                        font: .subheadline,
+                        color: .white.opacity(0.62)
+                    )
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .offset(
@@ -1954,10 +1979,13 @@ private struct MinimalTrackInfoRow: View {
                     VIPBadge()
                 }
             }
-            Text(player.currentTrack?.artistNames ?? "")
-                .font(.footnote)
-                .foregroundStyle(.white.opacity(0.62))
-                .lineLimit(1)
+            if let track = player.currentTrack {
+                NowPlayingTrackDestinationLinks(
+                    track: track,
+                    font: .footnote,
+                    color: .white.opacity(0.62)
+                )
+            }
         }
         .multilineTextAlignment(textAlignment)
         .accessibilityElement(children: .contain)

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -323,13 +323,13 @@ struct TrackRow: View {
         #endif
         Divider()
         if track.album.id > 0 {
-            NavigationLink(value: Destination.album(track.album.id)) {
-                Text("查看专辑")
+            Button("查看专辑") {
+                openDestination(.album(track.album.id))
             }
         }
-        ForEach(track.artists.prefix(3)) { artist in
-            NavigationLink(value: Destination.artist(artist.id)) {
-                Text("查看歌手：\(artist.name)")
+        ForEach(track.artists.filter { $0.id > 0 && !$0.name.isEmpty }.prefix(3)) { artist in
+            Button("查看歌手：\(artist.name)") {
+                openDestination(.artist(artist.id))
             }
         }
         Divider()

--- a/Sources/Kumone/Features/Shared/TrackList.swift
+++ b/Sources/Kumone/Features/Shared/TrackList.swift
@@ -31,6 +31,7 @@ struct TrackRow: View {
 
     @EnvironmentObject private var player: PlayerService
     @EnvironmentObject private var account: AccountStore
+    @Environment(\.openDestination) private var openDestination
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @ScaledMetric(relativeTo: .body) private var compactArtworkSize: CGFloat = 48
     @ScaledMetric(relativeTo: .body) private var compactRowHeight: CGFloat = 64
@@ -85,22 +86,30 @@ struct TrackRow: View {
                         VIPBadge()
                     }
                 }
-                Text(track.artistNames)
-                    .font(isCompact ? .footnote : .system(size: 11.5))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                artistLinks
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             if style == .full && !isCompact {
-                NavigationLink(value: Destination.album(track.album.id)) {
+                if track.album.id > 0, !track.album.name.isEmpty {
+                    Button {
+                        openDestination(.album(track.album.id))
+                    } label: {
+                        Text(track.album.name)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("打开专辑：\(track.album.name)")
+                    .frame(maxWidth: 220, alignment: .leading)
+                } else {
                     Text(track.album.name)
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .frame(maxWidth: 220, alignment: .leading)
                 }
-                .buttonStyle(.plain)
-                .frame(maxWidth: 220, alignment: .leading)
             }
 
             if let reason = playability.reason {
@@ -151,6 +160,21 @@ struct TrackRow: View {
 
     @ViewBuilder
     private var artwork: some View {
+        if track.album.id > 0, !track.album.name.isEmpty {
+            Button {
+                openDestination(.album(track.album.id))
+            } label: {
+                artworkImage
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("打开专辑：\(track.album.name)")
+        } else {
+            artworkImage
+        }
+    }
+
+    @ViewBuilder
+    private var artworkImage: some View {
         if isCompact {
             CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(160), animated: false)
                 .frame(width: compactArtworkSize, height: compactArtworkSize)
@@ -171,6 +195,35 @@ struct TrackRow: View {
             CachedAsyncImage(url: track.album.picUrl?.resizedImageURL(96), animated: false)
                 .frame(width: 42, height: 42)
                 .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.small, style: .continuous))
+        }
+    }
+
+    @ViewBuilder
+    private var artistLinks: some View {
+        let artists = track.artists.filter { $0.id > 0 && !$0.name.isEmpty }
+        if artists.isEmpty {
+            Text(track.artistNames)
+                .font(isCompact ? .footnote : .system(size: 11.5))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        } else {
+            HStack(spacing: 0) {
+                ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                    if index > 0 {
+                        Text(" / ")
+                    }
+                    Button {
+                        openDestination(.artist(artist.id))
+                    } label: {
+                        Text(artist.name)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("打开歌手：\(artist.name)")
+                }
+            }
+            .font(isCompact ? .footnote : .system(size: 11.5))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
         }
     }
 

--- a/Tests/KumoneCoreTests/NavigationDestinationTests.swift
+++ b/Tests/KumoneCoreTests/NavigationDestinationTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import KumoneCore
+
+@Suite("Navigation destination tests")
+struct NavigationDestinationTests {
+    @Test func doesNotAppendTheCurrentDestination() {
+        var destinations: [Destination] = [.artist(42)]
+
+        destinations.appendIfNotCurrent(.artist(42))
+
+        #expect(destinations == [.artist(42)])
+    }
+
+    @Test func appendsADifferentDestination() {
+        var destinations: [Destination] = [.album(7)]
+
+        destinations.appendIfNotCurrent(.artist(42))
+
+        #expect(destinations == [.album(7), .artist(42)])
+    }
+}


### PR DESCRIPTION
# feat(navigation): open artists and albums from tracks

## 背景

歌曲条目原本只能显示歌手和专辑信息。现在从歌曲列表、搜索结果和播放页可以直接进入对应的歌手或专辑详情页，并复用详情页现有的播放、队列和收藏能力。

Closes #80 

## 改动

### 歌曲信息导航

- 为歌曲列表、搜索结果和播放页补充歌手、专辑导航入口。
- 将目标映射为统一的 `Destination.artist` 与 `Destination.album`，由既有 `navigationDestination` 创建详情页。
- 播放页跳转后关闭播放页，详情页继续使用现有的播放和队列逻辑。

### 导航历史

- macOS、iPad 与 iPhone 的导航路径统一保存为 `[Destination]`，跳转前比较当前栈顶。
- 歌曲列表的行内入口、封面入口和右键菜单入口都通过同一个 `openDestination` 动作路由。
- 目标与当前导航栈顶相同时不再追加；打开不同歌手或专辑仍保留正常返回历史。
- 增加导航路径测试，覆盖相同目标不追加和不同目标追加。

### 播放页关闭与平台路由

- 仅当播放页显示时，先以现有动画移除播放页。
- 使用 `completionCriteria: .removed` 等待播放页视图退出层级后再写入导航路径。
- 常规歌曲列表和搜索结果的导航保持即时执行。
- iPad 播放页与 `MainWindow` 共享同一导航路径，关闭播放页后可进入对应详情页。
- 播放页导航闭包改为必传，避免接线遗漏时出现无响应点击。


## 验证

- `swift test`：12 项通过。
- `git diff --check`：通过。
- `Scripts/compile_and_run.sh debug`：构建成功并启动 macOS 调试版。
- iOS：受本机环境限制，未生成 iOS 产物；已完成路径所有权和条件编译分支的静态审查。


https://github.com/user-attachments/assets/6d98a6c8-b5a8-42fd-b4df-d3411b015188



## 影响范围

导航状态从 `NavigationPath` 调整为可比较的 `[Destination]`，用于统一栈顶去重。